### PR TITLE
Fix recording UX: GPS toggle, wake lock, trail proximity, back button, accuracy circle

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -66,6 +66,7 @@ const MapboxMap = memo(function MapboxMap() {
   const locationWatch = useRef<NodeJS.Timeout | undefined>(undefined);
   const wakeLock = useRef<WakeLockSentinel | null>(null);
   const [watchingLocation, setWatchingLocation] = useState(false);
+  const recordingActive = useRef(false);
 
   // Track markers for attractions and bike resources
   const attractionMarkers = useRef<MarkerManager>(new MarkerManager());
@@ -225,8 +226,9 @@ const MapboxMap = memo(function MapboxMap() {
       return;
     }
 
-    // When user interacts with map, disable location tracking
+    // When user interacts with map, disable location tracking (but not during recording)
     const disableTracking = () => {
+      if (recordingActive.current) return;
       setWatchingLocation(false);
       if (locationWatch.current) {
         clearInterval(locationWatch.current);
@@ -864,19 +866,16 @@ const MapboxMap = memo(function MapboxMap() {
           );
           bikeResourceMarkers.current.setMarkers(bikeResourceMarkerList);
 
-          // Update accuracy circle on zoom (batched to avoid jank during pinch-zoom)
-          let zoomRaf = 0;
+          // Update accuracy circle on zoom — synchronous so circle resizes in
+          // the same frame as the map (RAF batching caused a 1-frame lag)
           newMap.on('zoom', () => {
-            cancelAnimationFrame(zoomRaf);
-            zoomRaf = requestAnimationFrame(() => {
-              if (locationMarker.current && locationAccuracy.current > 0) {
-                updateAccuracyCircle(
-                  locationMarker.current,
-                  locationAccuracy.current,
-                  newMap.getZoom(),
-                );
-              }
-            });
+            if (locationMarker.current && locationAccuracy.current > 0) {
+              updateAccuracyCircle(
+                locationMarker.current,
+                locationAccuracy.current,
+                newMap.getZoom(),
+              );
+            }
           });
 
           // Add error handler
@@ -993,10 +992,12 @@ const MapboxMap = memo(function MapboxMap() {
   // Also toggle CSS class on map container for Mapbox control positioning
   useEffect(() => {
     const handleStart = () => {
+      recordingActive.current = true;
       setLocationWatch(true);
       mapContainer.current?.classList.add('recording-active');
     };
     const handleStop = () => {
+      recordingActive.current = false;
       setLocationWatch(false);
       mapContainer.current?.classList.remove('recording-active');
     };

--- a/src/components/RidesPanel.tsx
+++ b/src/components/RidesPanel.tsx
@@ -233,7 +233,7 @@ export function RidesPanel() {
           {toastMessage && (
             <div
               className={cn(
-                'absolute top-2 left-4 right-4 px-3 py-2 bg-gray-700 text-white rounded-md text-[13px] text-center animate-toast-slide-in z-10',
+                'absolute top-2 left-4 right-4 px-3 py-2 bg-gray-700 text-white rounded-md text-[13px] text-center animate-toast-slide-in z-10 pointer-events-none',
                 toastFadingOut &&
                   'opacity-0 transition-opacity duration-300 ease-in',
               )}

--- a/src/components/sidebar/ElevationProfile.tsx
+++ b/src/components/sidebar/ElevationProfile.tsx
@@ -159,8 +159,8 @@ export function findClosestProfileIndex(
     }
   }
 
-  // Only show if within ~200 meters (~0.002 degrees)
-  if (bestDist > 0.002 * 0.002) return null;
+  // Only show if within ~500 meters (~0.005 degrees)
+  if (bestDist > 0.005 * 0.005) return null;
 
   return bestIdx;
 }

--- a/src/components/sidebar/RideDetail.tsx
+++ b/src/components/sidebar/RideDetail.tsx
@@ -72,21 +72,14 @@ export function RideDetail({ ride, onClose, onDeleted }: RideDetailProps) {
 
   return (
     <div className="p-3">
-      <div
-        className="flex items-center gap-1.5 text-[13px] text-blue-500 cursor-pointer mb-2.5 py-0.5 hover:text-blue-600"
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-[13px] text-blue-500 cursor-pointer mb-2.5 py-2 px-1 -ml-1 bg-transparent border-none hover:text-blue-600"
         onClick={onClose}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onClose();
-          }
-        }}
-        role="button"
-        tabIndex={0}
       >
         <FontAwesomeIcon icon={faChevronLeft} />
         <span>Back</span>
-      </div>
+      </button>
 
       <div className="flex items-center justify-between gap-2 mb-1">
         {editing ? (


### PR DESCRIPTION
## Summary
- **GPS button + wake lock during recording**: Map touch/click gestures were disabling GPS tracking and releasing the wake lock even during active recording. Added a `recordingActive` guard so `disableTracking` is skipped while recording.
- **Trail proximity threshold**: Increased elevation profile location indicator threshold from ~200m to ~500m so GPS deviation while riding doesn't lose the blue dot.
- **Ride detail back button**: Converted from `<div role="button">` with tiny `py-0.5` padding to a proper `<button>` with `py-2` for reliable mobile tap target.
- **Accuracy circle zoom lag**: Removed `requestAnimationFrame` batching from the zoom handler so the circle resizes synchronously in the same frame as the map.

## Test plan
- [x] Start recording a ride, pan/zoom the map — GPS button should stay blue and screen should not sleep
- [ ] While GPS tracking on a trail, verify the blue dot stays on the elevation chart even with slight GPS drift
- [x] Tap the Back button in ride detail view on mobile — should work reliably on first tap
- [x] Zoom in/out while GPS dot is visible — accuracy circle should scale smoothly without lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)