### PR TITLE
Increase trail visibility and extend PWA to iOS notch

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,9 +10,17 @@
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
-html,
+html {
+  min-height: calc(100% + env(safe-area-inset-top));
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  width: 100%;
+  margin: 0;
+  overflow: hidden;
+  position: fixed;
+}
+
 body {
-  height: 100%;
+  height: 100dvh;
   width: 100%;
   margin: 0;
   padding: 0;
@@ -24,7 +32,7 @@ body {
 body > div,
 #__next,
 #root {
-  height: 100%;
+  height: 100dvh;
   width: 100%;
   overflow: hidden;
   position: fixed;

--- a/src/app/map.css
+++ b/src/app/map.css
@@ -1,6 +1,6 @@
 /* Shift Mapbox zoom/compass controls down to align with toggle buttons */
 .mapboxgl-ctrl-top-right {
-  top: 68px !important;
+  top: calc(68px + env(safe-area-inset-top)) !important;
   right: 12px !important;
   z-index: 900 !important;
   transition: top 0.2s ease;
@@ -9,7 +9,7 @@
 /* On mobile, push controls below the recording HUD */
 @media (max-width: 767px) {
   .recording-active .mapboxgl-ctrl-top-right {
-    top: 128px !important;
+    top: calc(128px + env(safe-area-inset-top)) !important;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import { MAP_EVENTS } from '@/events';
 const BikeMap = dynamic(() => import('@/components/Map'), {
   ssr: false,
   loading: () => (
-    <div className="w-full h-screen flex items-center justify-center bg-gray-100">
+    <div className="w-full h-dvh flex items-center justify-center bg-gray-100">
       Loading map...
     </div>
   ),
@@ -55,7 +55,7 @@ export default function Home(): ReactElement {
   }, []);
 
   return (
-    <main className="w-screen h-screen overflow-hidden absolute inset-0 m-0 p-0">
+    <main className="w-screen h-dvh overflow-hidden absolute inset-0 m-0 p-0">
       <BikeMap />
       <PwaInstallPrompt />
       <WelcomeModal />

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -869,8 +869,8 @@ const MapboxMap = memo(function MapboxMap() {
           for (const cfg of TRAIL_LAYERS) {
             if (!newMap.getLayer(cfg.layerId)) continue;
 
-            newMap.setPaintProperty(cfg.layerId, 'line-opacity', 0.15);
-            newMap.setPaintProperty(cfg.layerId, 'line-width', 2);
+            newMap.setPaintProperty(cfg.layerId, 'line-opacity', 0.35);
+            newMap.setPaintProperty(cfg.layerId, 'line-width', 3);
 
             // Click handler on hit-test layer for easier tapping
             const hId = `${cfg.layerId} Hit`;
@@ -1103,7 +1103,7 @@ const MapboxMap = memo(function MapboxMap() {
       {toastMessage && (
         <div
           className={cn(
-            'absolute top-5 left-1/2 -translate-x-1/2 bg-black/65 text-white px-6 py-3 rounded-lg text-base font-medium z-[800] shadow-[0_4px_12px_rgba(0,0,0,0.3)] pointer-events-none animate-toast-fade-in',
+            'absolute left-1/2 -translate-x-1/2 bg-black/65 text-white px-6 py-3 rounded-lg text-base font-medium z-[800] shadow-[0_4px_12px_rgba(0,0,0,0.3)] pointer-events-none animate-toast-fade-in top-[calc(1.25rem+env(safe-area-inset-top))]',
             toastFadingOut && 'animate-toast-fade-out',
           )}
         >
@@ -1156,7 +1156,7 @@ const MapboxMap = memo(function MapboxMap() {
 export default function BikeMap() {
   return (
     <MapLegendProvider>
-      <div className="w-screen h-screen relative overflow-visible">
+      <div className="w-screen h-dvh relative overflow-visible">
         <MapboxMap />
         <RidesPanel />
       </div>

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -310,7 +310,7 @@ export function MapLegendProvider({ children }: { children: React.ReactNode }) {
       <div
         ref={sidebarRef}
         className={cn(
-          'fixed top-0 left-0 h-full w-[280px] bg-white shadow-[2px_0_5px_rgba(0,0,0,0.1)] z-[950] overflow-hidden transition-transform duration-300 ease-in-out max-md:w-full max-md:max-w-[320px]',
+          'fixed top-0 left-0 h-full w-[280px] bg-white shadow-[2px_0_5px_rgba(0,0,0,0.1)] z-[950] overflow-hidden transition-transform duration-300 ease-in-out flex flex-col max-md:w-full max-md:max-w-[320px]',
           isOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >
@@ -344,7 +344,7 @@ export function MapLegendProvider({ children }: { children: React.ReactNode }) {
           </div>
         </div>
 
-        <div className="overflow-y-auto h-[calc(100%-79px)]">
+        <div className="overflow-y-auto flex-1 min-h-0">
           <div className="px-4 pb-4 pt-2">
             {activeSection === 'routes' && (
               <>

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -287,7 +287,12 @@ export function MapLegendProvider({ children }: { children: React.ReactNode }) {
       {children}
 
       {/* Toggle button */}
-      <div className={cn('fixed top-4 left-4', isOpen ? 'z-[960]' : 'z-[900]')}>
+      <div
+        className={cn(
+          'fixed left-4 top-[calc(1rem+env(safe-area-inset-top))]',
+          isOpen ? 'z-[960]' : 'z-[900]',
+        )}
+      >
         <button
           ref={toggleButtonRef}
           onClick={toggle}
@@ -310,7 +315,7 @@ export function MapLegendProvider({ children }: { children: React.ReactNode }) {
         )}
       >
         {/* Casual / MTB toggle in header */}
-        <div className="flex justify-center items-center py-[17px] px-4 pl-[68px] pb-3 border-b border-gray-200 bg-gray-50">
+        <div className="flex justify-center items-center py-[17px] px-4 pl-[68px] pb-3 border-b border-gray-200 bg-gray-50 pt-[calc(17px+env(safe-area-inset-top))]">
           <div className="flex bg-gray-100 rounded-full p-1 w-full border border-gray-200">
             <button
               type="button"

--- a/src/components/RidesPanel.tsx
+++ b/src/components/RidesPanel.tsx
@@ -164,7 +164,7 @@ export function RidesPanel() {
       {/* Toggle button */}
       <div
         className={cn(
-          'fixed top-5 right-4',
+          'fixed right-4 top-[calc(1.25rem+env(safe-area-inset-top))]',
           isOpen ? 'z-[960]' : 'z-[900]',
           isRecording && !isOpen && 'animate-recording-pulse rounded-full',
         )}
@@ -188,7 +188,7 @@ export function RidesPanel() {
 
       {/* Floating recording HUD — visible when recording with panel closed */}
       {isRecording && !isOpen && (
-        <div className="fixed top-[22px] left-1/2 -translate-x-1/2 z-[800] bg-white rounded-xl shadow-lg h-10 px-3 flex items-center gap-2.5 text-sm max-md:top-[76px] max-md:left-2 max-md:right-2 max-md:translate-x-0">
+        <div className="fixed top-[calc(22px+env(safe-area-inset-top))] left-1/2 -translate-x-1/2 z-[800] bg-white rounded-xl shadow-lg h-10 px-3 flex items-center gap-2.5 text-sm max-md:top-[calc(76px+env(safe-area-inset-top))] max-md:left-2 max-md:right-2 max-md:translate-x-0">
           <PulseDot />
           <span className="font-bold tabular-nums text-gray-700">
             {formatElapsed(elapsedTime)}
@@ -229,7 +229,7 @@ export function RidesPanel() {
           isOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none',
         )}
       >
-        <div className="px-4 pt-4 pb-2 border-b border-gray-200">
+        <div className="px-4 pb-2 border-b border-gray-200 pt-[calc(1rem+env(safe-area-inset-top))]">
           <h2 className="m-0 text-base font-semibold text-gray-700">
             My Rides
           </h2>

--- a/src/utils/map.test.ts
+++ b/src/utils/map.test.ts
@@ -510,12 +510,12 @@ describe('updateMtnBikeOpacity', () => {
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-opacity',
-      ['case', ['==', ['get', 'Trail'], 'Five Points'], 0.9, 0.15],
+      ['case', ['==', ['get', 'Trail'], 'Five Points'], 0.9, 0.5],
     );
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-width',
-      ['case', ['==', ['get', 'Trail'], 'Five Points'], 4, 2],
+      ['case', ['==', ['get', 'Trail'], 'Five Points'], 4, 3],
     );
   });
 
@@ -530,12 +530,12 @@ describe('updateMtnBikeOpacity', () => {
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-opacity',
-      0.15,
+      0.5,
     );
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-width',
-      2,
+      3,
     );
   });
 
@@ -628,12 +628,12 @@ describe('highlightMtnBikeArea', () => {
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-opacity',
-      ['match', ['get', 'Trail'], ['Trail A', 'Trail B'], 0.9, 0.1],
+      ['match', ['get', 'Trail'], ['Trail A', 'Trail B'], 0.9, 0.4],
     );
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'SORBA Regional Trails',
       'line-width',
-      ['match', ['get', 'Trail'], ['Trail A', 'Trail B'], 3, 2],
+      ['match', ['get', 'Trail'], ['Trail A', 'Trail B'], 3, 3],
     );
   });
 
@@ -760,7 +760,7 @@ describe('updateMtnBikeOpacity with Godsey Ridge trail', () => {
     expect(mockMap.setPaintProperty).toHaveBeenCalledWith(
       'Godsey Ridge Trails',
       'line-opacity',
-      ['case', ['==', ['get', 'Name'], 'Green as built'], 0.9, 0.15],
+      ['case', ['==', ['get', 'Name'], 'Green as built'], 0.9, 0.5],
     );
   });
 });

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -368,13 +368,13 @@ function setTrailOpacity(
       'case',
       ['==', ['get', prop], matchValue],
       0.9,
-      0.15,
+      0.5,
     ]);
     map.setPaintProperty(cfg.layerId, 'line-width', [
       'case',
       ['==', ['get', prop], matchValue],
       4,
-      2,
+      3,
     ]);
 
     if (map.getLayer(cId)) {
@@ -382,13 +382,13 @@ function setTrailOpacity(
         'case',
         ['==', ['get', prop], matchValue],
         0.9,
-        0.25,
+        0.5,
       ]);
       map.setPaintProperty(cId, 'line-width', [
         'case',
         ['==', ['get', prop], matchValue],
         6,
-        4,
+        5,
       ]);
     }
 
@@ -407,12 +407,12 @@ function setTrailOpacity(
       ]);
     }
   } else {
-    map.setPaintProperty(cfg.layerId, 'line-opacity', 0.15);
-    map.setPaintProperty(cfg.layerId, 'line-width', 2);
+    map.setPaintProperty(cfg.layerId, 'line-opacity', 0.5);
+    map.setPaintProperty(cfg.layerId, 'line-width', 3);
 
     if (map.getLayer(cId)) {
-      map.setPaintProperty(cId, 'line-opacity', 0.25);
-      map.setPaintProperty(cId, 'line-width', 4);
+      map.setPaintProperty(cId, 'line-opacity', 0.5);
+      map.setPaintProperty(cId, 'line-width', 5);
     }
 
     if (map.getLayer(gId)) {
@@ -470,14 +470,14 @@ export function highlightMtnBikeArea(
         ['get', cfg.trailProp],
         rawNames,
         0.9,
-        0.1,
+        0.4,
       ]);
       map.setPaintProperty(cfg.layerId, 'line-width', [
         'match',
         ['get', cfg.trailProp],
         rawNames,
         3,
-        2,
+        3,
       ]);
 
       if (map.getLayer(cId)) {
@@ -486,14 +486,14 @@ export function highlightMtnBikeArea(
           ['get', cfg.trailProp],
           rawNames,
           0.6,
-          0.1,
+          0.4,
         ]);
         map.setPaintProperty(cId, 'line-width', [
           'match',
           ['get', cfg.trailProp],
           rawNames,
           5,
-          4,
+          5,
         ]);
       }
 


### PR DESCRIPTION
## Summary
- **Trail visibility**: Increased unselected/deselected trail opacity from 0.10–0.15 to 0.40–0.50 and line width from 2px to 3px (casing 4→5) across all contexts (init, trail selected, no trail selected, area highlight)
- **iOS PWA notch**: Applied `viewport-fit=cover` pattern so the app extends behind the notch — added `min-height: calc(100% + env(safe-area-inset-top))` with safe-area padding on `<html>`, switched to `100dvh` heights, and offset all fixed UI elements by `env(safe-area-inset-top)` (hamburger/rides buttons, toast, recording HUD, Mapbox controls, sidebar header, rides panel header)

## Test plan
- [ ] Verify unselected trails are clearly visible when a single trail is selected
- [ ] Verify unselected trails are visible when an area is highlighted
- [ ] Verify trail init opacity/width on page load
- [ ] Test on iPhone with notch (PWA added to home screen) — app should fill behind notch/Dynamic Island
- [ ] Verify sidebar header, toggle buttons, and toast don't overlap with notch
- [ ] Verify recording HUD clears the notch area
- [ ] Test on non-notch devices — no layout regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)