### PR TITLE
Fix share links and zoom reset during recording

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -64,8 +64,9 @@ describe('Home — share link URL parameter handling', () => {
   afterEach(() => {
     cleanup();
     dispatchSpy.mockRestore();
-    // Reset URL
+    // Reset URL and __mapReady flag
     window.history.replaceState(null, '', '/');
+    delete (window as unknown as Record<string, boolean>).__mapReady;
   });
 
   it('dispatches TRAIL_SELECT on MAP_READY when ?trail= matches', () => {
@@ -151,6 +152,25 @@ describe('Home — share link URL parameter handling', () => {
       ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
     );
     expect(trailEvents).toHaveLength(1);
+  });
+
+  it('selects immediately via __mapReady flag without waiting for event', () => {
+    (window as unknown as Record<string, boolean>).__mapReady = true;
+    window.history.replaceState(
+      null,
+      '',
+      '/?trail=mouse-creek-greenway-phase-1',
+    );
+    render(<Home />);
+
+    // Should have dispatched immediately, without needing MAP_READY event
+    const trailEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    expect(trailEvents).toHaveLength(1);
+    expect((trailEvents[0][0] as CustomEvent).detail.trailName).toBe(
+      'Mouse Creek Greenway Phase 1',
+    );
   });
 
   it('prefers trail param when both trail and route are present', () => {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MAP_EVENTS } from '@/events';
+
+// Mock next/dynamic to render a simple placeholder instead of the real Map
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => {
+    const Stub = () => <div data-testid="map-stub" />;
+    Stub.displayName = 'DynamicMap';
+    return Stub;
+  },
+}));
+
+// Mock child components
+vi.mock('@/components/PwaInstallPrompt', () => ({
+  PwaInstallPrompt: () => <div data-testid="pwa-stub" />,
+}));
+vi.mock('@/components/WelcomeModal', () => ({
+  WelcomeModal: () => <div data-testid="welcome-stub" />,
+}));
+
+// Mock geo data with known trails and routes
+vi.mock('@/data/geo_data', () => ({
+  mountainBikeTrails: [
+    {
+      trailName: 'Mouse Creek Greenway Phase 1',
+      displayName: 'Mouse Creek Greenway Phase 1',
+      recArea: 'Cleveland',
+      rating: '',
+      color: '#059669',
+      distance: 0.6,
+      elevationGain: 15,
+      elevationLoss: 14,
+      elevationMin: 790,
+      elevationMax: 804,
+      defaultBounds: [-84.876938, 35.175211, -84.87299, 35.182087],
+    },
+  ],
+  bikeRoutes: [
+    {
+      id: 'zoo-loop-v2-full-public',
+      name: 'Zoo Loop',
+      color: '#DC2626',
+      description: 'Zoo route',
+      defaultWidth: 8,
+      opacity: 1.0,
+      defaultBounds: [-85.307614, 35.037548, -85.281097, 35.061733],
+    },
+  ],
+}));
+
+// Import Home after mocks are set up
+import Home from './page';
+
+describe('Home — share link URL parameter handling', () => {
+  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+  });
+
+  afterEach(() => {
+    cleanup();
+    dispatchSpy.mockRestore();
+    // Reset URL
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('dispatches TRAIL_SELECT on MAP_READY when ?trail= matches', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/?trail=mouse-creek-greenway-phase-1',
+    );
+    render(<Home />);
+
+    // Before MAP_READY fires, no TRAIL_SELECT should have been dispatched
+    const trailEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    expect(trailEvents).toHaveLength(0);
+
+    // Simulate map ready
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const afterReady = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    expect(afterReady).toHaveLength(1);
+
+    const detail = (afterReady[0][0] as CustomEvent).detail;
+    expect(detail.trailName).toBe('Mouse Creek Greenway Phase 1');
+  });
+
+  it('dispatches ROUTE_SELECT on MAP_READY when ?route= matches', () => {
+    window.history.replaceState(null, '', '/?route=zoo-loop');
+    render(<Home />);
+
+    // Simulate map ready
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const routeEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.ROUTE_SELECT,
+    );
+    expect(routeEvents).toHaveLength(1);
+    expect((routeEvents[0][0] as CustomEvent).detail.routeId).toBe(
+      'zoo-loop-v2-full-public',
+    );
+  });
+
+  it('does not dispatch anything when URL has no trail or route param', () => {
+    window.history.replaceState(null, '', '/');
+    render(<Home />);
+
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const selectEvents = dispatchSpy.mock.calls.filter(
+      ([e]) =>
+        (e as Event).type === MAP_EVENTS.TRAIL_SELECT ||
+        (e as Event).type === MAP_EVENTS.ROUTE_SELECT,
+    );
+    expect(selectEvents).toHaveLength(0);
+  });
+
+  it('does not dispatch when trail slug does not match any trail', () => {
+    window.history.replaceState(null, '', '/?trail=nonexistent-trail');
+    render(<Home />);
+
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const trailEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    expect(trailEvents).toHaveLength(0);
+  });
+
+  it('only fires once even if MAP_READY is dispatched multiple times', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/?trail=mouse-creek-greenway-phase-1',
+    );
+    render(<Home />);
+
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const trailEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    expect(trailEvents).toHaveLength(1);
+  });
+
+  it('prefers trail param when both trail and route are present', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/?trail=mouse-creek-greenway-phase-1&route=zoo-loop',
+    );
+    render(<Home />);
+
+    window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
+
+    const trailEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.TRAIL_SELECT,
+    );
+    const routeEvents = dispatchSpy.mock.calls.filter(
+      ([e]) => (e as Event).type === MAP_EVENTS.ROUTE_SELECT,
+    );
+    expect(trailEvents).toHaveLength(1);
+    expect(routeEvents).toHaveLength(0);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,12 @@ export default function Home(): ReactElement {
       }
     };
 
-    // Wait for the map to be fully initialized before selecting
+    // If the map already initialized before this effect ran, select now.
+    // Otherwise wait for the MAP_READY event.
+    if ((window as unknown as Record<string, boolean>).__mapReady) {
+      selectFromUrl();
+      return;
+    }
     window.addEventListener(MAP_EVENTS.MAP_READY, selectFromUrl, {
       once: true,
     });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,32 +26,38 @@ export default function Home(): ReactElement {
     const trailSlug = params.get('trail');
     const routeSlug = params.get('route');
 
-    if (trailSlug) {
-      const found = mountainBikeTrails.find(
-        (t) => slugify(t.trailName) === trailSlug,
-      );
-      if (found) {
-        // Delay to let the map initialize
-        setTimeout(() => {
+    if (!trailSlug && !routeSlug) return;
+
+    const selectFromUrl = () => {
+      if (trailSlug) {
+        const found = mountainBikeTrails.find(
+          (t) => slugify(t.trailName) === trailSlug,
+        );
+        if (found) {
           window.dispatchEvent(
             new CustomEvent(MAP_EVENTS.TRAIL_SELECT, {
               detail: { trailName: found.trailName },
             }),
           );
-        }, 2000);
-      }
-    } else if (routeSlug) {
-      const found = bikeRoutes.find((r) => slugify(r.name) === routeSlug);
-      if (found) {
-        setTimeout(() => {
+        }
+      } else if (routeSlug) {
+        const found = bikeRoutes.find((r) => slugify(r.name) === routeSlug);
+        if (found) {
           window.dispatchEvent(
             new CustomEvent(MAP_EVENTS.ROUTE_SELECT, {
               detail: { routeId: found.id },
             }),
           );
-        }, 2000);
+        }
       }
-    }
+    };
+
+    // Wait for the map to be fully initialized before selecting
+    window.addEventListener(MAP_EVENTS.MAP_READY, selectFromUrl, {
+      once: true,
+    });
+    return () =>
+      window.removeEventListener(MAP_EVENTS.MAP_READY, selectFromUrl);
   }, []);
 
   return (

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1131,6 +1131,8 @@ const MapboxMap = memo(function MapboxMap() {
   // Attach compass (device orientation) listener to rotate the map bearing.
   // Applies bearing directly in the orientation handler for smooth rotation.
   const attachCompassListener = () => {
+    let receivedFirst = false;
+
     const handler = (e: DeviceOrientationEvent) => {
       // iOS provides webkitCompassHeading (degrees from north, clockwise)
       const evt = e as DeviceOrientationEvent & {
@@ -1143,6 +1145,11 @@ const MapboxMap = memo(function MapboxMap() {
         heading = (360 - e.alpha) % 360;
       }
       if (heading === null) return;
+
+      if (!receivedFirst) {
+        receivedFirst = true;
+        showToast(`Compass: ${Math.round(heading)}°`);
+      }
 
       // Skip tiny changes (< 2°) to reduce jumpTo calls.
       // The > 358 check handles wraparound (e.g. 359° → 1° = 2°).
@@ -1179,6 +1186,16 @@ const MapboxMap = memo(function MapboxMap() {
         window.removeEventListener(evt, handler as EventListener);
       }
     };
+
+    showToast(`Compass: listening on ${events.join(', ')}`);
+
+    // If no data after 3 seconds, notify
+    setTimeout(() => {
+      if (!receivedFirst && compassHeading.current === null) {
+        showToast('No compass data — sensor may not be available');
+      }
+    }, 3000);
+
     setCompassMode(true);
   };
 
@@ -1197,8 +1214,8 @@ const MapboxMap = memo(function MapboxMap() {
       if (DOE.requestPermission) {
         try {
           const permission = await DOE.requestPermission();
+          showToast(`Orientation permission: ${permission}`);
           if (permission !== 'granted') {
-            // Permission denied — fall through to off
             setLocationWatch(false);
             return;
           }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -325,8 +325,18 @@ const MapboxMap = memo(function MapboxMap() {
       });
       updateMtnBikeOpacity(map.current, null);
 
-      if (selectedRoute?.bounds) {
-        flyToBounds(map.current, selectedRoute.bounds);
+      // Fall back to defaultBounds when runtime bounds aren't available
+      const bounds =
+        selectedRoute?.bounds ??
+        (selectedRoute?.defaultBounds
+          ? new mapboxgl.LngLatBounds(
+              [selectedRoute.defaultBounds[0], selectedRoute.defaultBounds[1]],
+              [selectedRoute.defaultBounds[2], selectedRoute.defaultBounds[3]],
+            )
+          : undefined);
+
+      if (bounds) {
+        flyToBounds(map.current, bounds);
       }
     },
     [showToast],
@@ -364,9 +374,20 @@ const MapboxMap = memo(function MapboxMap() {
           calculateTrailBounds(map.current, trailName) ?? undefined;
       }
 
+      // Fall back to defaultBounds when runtime bounds aren't available
+      // (e.g. trail tiles not loaded for the current viewport)
+      const bounds =
+        trail?.bounds ??
+        (trail?.defaultBounds
+          ? new mapboxgl.LngLatBounds(
+              [trail.defaultBounds[0], trail.defaultBounds[1]],
+              [trail.defaultBounds[2], trail.defaultBounds[3]],
+            )
+          : undefined);
+
       // Skip flyToBounds for auto-detected trails (map already follows user)
-      if (!autoDetected && trail?.bounds) {
-        flyToBounds(map.current, trail.bounds);
+      if (!autoDetected && bounds) {
+        flyToBounds(map.current, bounds);
       }
     },
     [showToast],
@@ -954,6 +975,9 @@ const MapboxMap = memo(function MapboxMap() {
           newMap.on('error', (event: { error: Error }) => {
             console.error('Map error:', event.error);
           });
+
+          // Signal that the map is fully initialized and ready for events
+          window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
         } catch (error) {
           console.error('Error initializing map:', error);
         }
@@ -1030,8 +1054,13 @@ const MapboxMap = memo(function MapboxMap() {
 
       // Continuously re-center on current position using jumpTo (no animation)
       // so the map is never mid-flight, which would block route-layer tap events.
+      // Skip when the user is mid-gesture (pinch-zoom, drag) so we don't
+      // interrupt and snap the zoom back — this was causing #57.
       locationWatch.current = setInterval(() => {
         if (!map.current || !locationMarker.current) {
+          return;
+        }
+        if (map.current.isMoving() || map.current.isZooming()) {
           return;
         }
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -139,8 +139,8 @@ const MapboxMap = memo(function MapboxMap() {
     const liveCoords: [number, number][] = [];
     let updateSkip = 0;
     const DETECT_INTERVAL_MS = 3000;
-    const DETECT_CONFIRM_COUNT = 2; // ~6s before first auto-select
-    const DETECT_SWITCH_COUNT = 4; // ~12s before switching or clearing
+    const DETECT_CONFIRM_COUNT = 3; // ~9s before first auto-select
+    const DETECT_SWITCH_COUNT = 5; // ~15s before switching or clearing
 
     const updateHandler = (e: Event) => {
       if (!map.current) return;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -798,8 +798,20 @@ const MapboxMap = memo(function MapboxMap() {
             });
           });
 
-          // Set initial line width for specific layers
+          // Find the first symbol/label layer — route lines will be
+          // inserted below it so street names remain visible on top.
           const style = newMap.getStyle();
+          let firstSymbolId: string | undefined;
+          if (style?.layers) {
+            for (const l of style.layers) {
+              if (l.type === 'symbol') {
+                firstSymbolId = l.id;
+                break;
+              }
+            }
+          }
+
+          // Set initial line width for specific layers
           if (style?.layers) {
             style.layers.forEach((layer) => {
               if (layer.type === 'line') {
@@ -814,6 +826,11 @@ const MapboxMap = memo(function MapboxMap() {
                   newMap.setPaintProperty(layer.id, 'line-opacity', 0.2);
                   newMap.setLayoutProperty(layer.id, 'line-cap', 'round');
                   newMap.setLayoutProperty(layer.id, 'line-join', 'round');
+
+                  // Move route layer below labels so street names show
+                  if (firstSymbolId) {
+                    newMap.moveLayer(layer.id, firstSymbolId);
+                  }
 
                   // Add white casing layer beneath the route
                   const casingId = `${layer.id}-casing`;
@@ -841,7 +858,7 @@ const MapboxMap = memo(function MapboxMap() {
                         },
                         ...(layer.filter ? { filter: layer.filter } : {}),
                       },
-                      layer.id,
+                      layer.id, // casing goes directly below route
                     );
                   }
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1128,23 +1128,9 @@ const MapboxMap = memo(function MapboxMap() {
     }
   };
 
-  // Start compass (device orientation) to rotate the map bearing.
-  // Applies bearing directly in the orientation handler for smooth rotation
-  // instead of waiting for the 1-second setInterval.
-  const startCompass = async () => {
-    // iOS 13+ requires explicit permission
-    const DOE = DeviceOrientationEvent as unknown as {
-      requestPermission?: () => Promise<string>;
-    };
-    if (DOE.requestPermission) {
-      try {
-        const permission = await DOE.requestPermission();
-        if (permission !== 'granted') return;
-      } catch {
-        return;
-      }
-    }
-
+  // Attach compass (device orientation) listener to rotate the map bearing.
+  // Applies bearing directly in the orientation handler for smooth rotation.
+  const attachCompassListener = () => {
     const handler = (e: DeviceOrientationEvent) => {
       // iOS provides webkitCompassHeading (degrees from north, clockwise)
       const evt = e as DeviceOrientationEvent & {
@@ -1154,15 +1140,12 @@ const MapboxMap = memo(function MapboxMap() {
       if (typeof evt.webkitCompassHeading === 'number') {
         heading = evt.webkitCompassHeading;
       } else if (typeof e.alpha === 'number') {
-        // Standard API: alpha is degrees counterclockwise from north
-        // when absolute, or from an arbitrary reference when not.
-        // Either way, (360 - alpha) gives a clockwise-from-north bearing.
         heading = (360 - e.alpha) % 360;
       }
       if (heading === null) return;
 
-      // Skip tiny changes (< 2°) to avoid excessive jumpTo calls (~60 Hz).
-      // The > 358 check handles wraparound (e.g. 359° → 1° is only 2°).
+      // Skip tiny changes (< 2°) to reduce jumpTo calls.
+      // The > 358 check handles wraparound (e.g. 359° → 1° = 2°).
       const prev = compassHeading.current;
       if (prev !== null) {
         const diff = Math.abs(heading - prev);
@@ -1171,7 +1154,6 @@ const MapboxMap = memo(function MapboxMap() {
 
       compassHeading.current = heading;
 
-      // Apply bearing immediately for smooth rotation
       if (map.current && !map.current.isMoving() && !map.current.isZooming()) {
         map.current.jumpTo({ bearing: heading });
       }
@@ -1179,8 +1161,7 @@ const MapboxMap = memo(function MapboxMap() {
 
     // Prefer 'deviceorientationabsolute' (Android Chrome) which gives
     // compass-relative values.  Fall back to 'deviceorientation' (iOS,
-    // other browsers) which provides webkitCompassHeading on iOS and
-    // may give relative-only alpha on some Android devices.
+    // other browsers) which provides webkitCompassHeading on iOS.
     const useAbsolute = 'ondeviceorientationabsolute' in window;
     const eventName = useAbsolute
       ? 'deviceorientationabsolute'
@@ -1193,14 +1174,32 @@ const MapboxMap = memo(function MapboxMap() {
     setCompassMode(true);
   };
 
-  // Toggle location tracking: off → tracking (north-up) → compass (heading-up) → off
-  const toggleWatchLocation = () => {
+  // Toggle location tracking: off → tracking (north-up) → compass (heading-up) → off.
+  // The permission request for iOS is done inline (not in a nested async) so it
+  // stays within the user-gesture context that Safari requires.
+  const toggleWatchLocation = async () => {
     if (!watchingLocation) {
       // off → tracking
       setLocationWatch(true);
     } else if (!compassMode) {
-      // tracking → compass
-      startCompass();
+      // tracking → compass: request permission (iOS), then attach listener
+      const DOE = DeviceOrientationEvent as unknown as {
+        requestPermission?: () => Promise<string>;
+      };
+      if (DOE.requestPermission) {
+        try {
+          const permission = await DOE.requestPermission();
+          if (permission !== 'granted') {
+            // Permission denied — fall through to off
+            setLocationWatch(false);
+            return;
+          }
+        } catch {
+          setLocationWatch(false);
+          return;
+        }
+      }
+      attachCompassListener();
     } else {
       // compass → off
       setLocationWatch(false);

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1129,49 +1129,53 @@ const MapboxMap = memo(function MapboxMap() {
   };
 
   // Attach compass (device orientation) listener to rotate the map bearing.
-  // Applies bearing directly in the orientation handler for smooth rotation.
+  // Uses a low-pass filter to smooth heading and prevent jitter when the
+  // phone is held upright (gimbal lock region).
   const attachCompassListener = () => {
-    let receivedFirst = false;
+    // Low-pass filter weight: 0 = ignore new readings, 1 = no smoothing.
+    // 0.15 gives a smooth ~200ms response while damping oscillation.
+    const SMOOTHING = 0.15;
+    let smoothed: number | null = null;
 
     const handler = (e: DeviceOrientationEvent) => {
-      // iOS provides webkitCompassHeading (degrees from north, clockwise)
       const evt = e as DeviceOrientationEvent & {
         webkitCompassHeading?: number;
       };
-      let heading: number | null = null;
+      let raw: number | null = null;
       if (typeof evt.webkitCompassHeading === 'number') {
-        heading = evt.webkitCompassHeading;
+        raw = evt.webkitCompassHeading;
       } else if (typeof e.alpha === 'number') {
-        heading = (360 - e.alpha) % 360;
+        raw = (360 - e.alpha) % 360;
       }
-      if (heading === null) return;
+      if (raw === null) return;
 
-      if (!receivedFirst) {
-        receivedFirst = true;
-        showToast(`Compass: ${Math.round(heading)}°`);
+      // Low-pass filter using circular (angular) interpolation to avoid
+      // the 359°→1° wraparound jump.
+      if (smoothed === null) {
+        smoothed = raw;
+      } else {
+        let delta = raw - smoothed;
+        // Shortest-path wraparound
+        if (delta > 180) delta -= 360;
+        else if (delta < -180) delta += 360;
+        smoothed = (smoothed + SMOOTHING * delta + 360) % 360;
       }
 
-      // Skip tiny changes (< 2°) to reduce jumpTo calls.
-      // The > 358 check handles wraparound (e.g. 359° → 1° = 2°).
+      // Only update map when the smoothed heading changes enough
       const prev = compassHeading.current;
       if (prev !== null) {
-        const diff = Math.abs(heading - prev);
-        if (diff < 2 || diff > 358) return;
+        let diff = Math.abs(smoothed - prev);
+        if (diff > 180) diff = 360 - diff;
+        if (diff < 1) return;
       }
 
-      compassHeading.current = heading;
-
-      // Always apply bearing — don't gate on isMoving/isZooming since the
-      // user expects the map to track their heading continuously.
+      compassHeading.current = smoothed;
       if (map.current) {
-        map.current.jumpTo({ bearing: heading });
+        map.current.jumpTo({ bearing: smoothed });
       }
     };
 
-    // Listen to both event types when available.  Android Chrome fires
-    // 'deviceorientationabsolute' with compass-relative alpha; iOS fires
-    // 'deviceorientation' with webkitCompassHeading.  If the device
-    // supports absolute, also listen to the standard event as a fallback.
+    // Listen to both event types when available.
     const events: string[] = [];
     if ('ondeviceorientationabsolute' in window) {
       events.push('deviceorientationabsolute');
@@ -1186,16 +1190,6 @@ const MapboxMap = memo(function MapboxMap() {
         window.removeEventListener(evt, handler as EventListener);
       }
     };
-
-    showToast(`Compass: listening on ${events.join(', ')}`);
-
-    // If no data after 3 seconds, notify
-    setTimeout(() => {
-      if (!receivedFirst && compassHeading.current === null) {
-        showToast('No compass data — sensor may not be available');
-      }
-    }, 3000);
-
     setCompassMode(true);
   };
 
@@ -1214,7 +1208,6 @@ const MapboxMap = memo(function MapboxMap() {
       if (DOE.requestPermission) {
         try {
           const permission = await DOE.requestPermission();
-          showToast(`Orientation permission: ${permission}`);
           if (permission !== 'granted') {
             setLocationWatch(false);
             return;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1112,7 +1112,9 @@ const MapboxMap = memo(function MapboxMap() {
     }
   };
 
-  // Start compass (device orientation) to rotate the map bearing
+  // Start compass (device orientation) to rotate the map bearing.
+  // Applies bearing directly in the orientation handler for smooth rotation
+  // instead of waiting for the 1-second setInterval.
   const startCompass = async () => {
     // iOS 13+ requires explicit permission
     const DOE = DeviceOrientationEvent as unknown as {
@@ -1129,24 +1131,40 @@ const MapboxMap = memo(function MapboxMap() {
 
     const handler = (e: DeviceOrientationEvent) => {
       // iOS provides webkitCompassHeading (degrees from north, clockwise)
-      // Android/standard uses alpha (degrees, counterclockwise from north)
       const evt = e as DeviceOrientationEvent & {
         webkitCompassHeading?: number;
       };
       let heading: number | null = null;
       if (typeof evt.webkitCompassHeading === 'number') {
         heading = evt.webkitCompassHeading;
-      } else if (typeof e.alpha === 'number' && e.absolute) {
+      } else if (typeof e.alpha === 'number') {
+        // Standard API: alpha is degrees counterclockwise from north
+        // when absolute, or from an arbitrary reference when not.
+        // Either way, (360 - alpha) gives a clockwise-from-north bearing.
         heading = (360 - e.alpha) % 360;
       }
-      if (heading !== null) {
-        compassHeading.current = heading;
+      if (heading === null) return;
+
+      compassHeading.current = heading;
+
+      // Apply bearing immediately for smooth rotation
+      if (map.current && !map.current.isMoving() && !map.current.isZooming()) {
+        map.current.jumpTo({ bearing: heading });
       }
     };
 
-    window.addEventListener('deviceorientation', handler, true);
+    // Prefer 'deviceorientationabsolute' (Android Chrome) which gives
+    // compass-relative values.  Fall back to 'deviceorientation' (iOS,
+    // other browsers) which provides webkitCompassHeading on iOS and
+    // may give relative-only alpha on some Android devices.
+    const useAbsolute = 'ondeviceorientationabsolute' in window;
+    const eventName = useAbsolute
+      ? 'deviceorientationabsolute'
+      : 'deviceorientation';
+
+    window.addEventListener(eventName, handler as EventListener, true);
     compassCleanup.current = () => {
-      window.removeEventListener('deviceorientation', handler, true);
+      window.removeEventListener(eventName, handler as EventListener, true);
     };
     setCompassMode(true);
   };

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -284,10 +284,11 @@ const MapboxMap = memo(function MapboxMap() {
       return;
     }
 
-    // When user intentionally moves the map, disable location tracking (but not during recording).
+    // When user intentionally moves the map, pause auto-center.
+    // During recording this only pauses centering (keeps wake lock & recording);
+    // user can tap the location button to resume.
     // Using dragstart/dblclick/wheel instead of click so route-layer taps aren't swallowed.
     const disableTracking = () => {
-      if (recordingActive.current) return;
       setWatchingLocation(false);
       setCompassMode(false);
       if (compassCleanup.current) {
@@ -299,7 +300,8 @@ const MapboxMap = memo(function MapboxMap() {
         clearInterval(locationWatch.current);
         locationWatch.current = undefined;
       }
-      if (wakeLock.current) {
+      // Keep wake lock alive during recording so the screen stays on
+      if (!recordingActive.current && wakeLock.current) {
         wakeLock.current.release();
         wakeLock.current = null;
       }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1154,22 +1154,30 @@ const MapboxMap = memo(function MapboxMap() {
 
       compassHeading.current = heading;
 
-      if (map.current && !map.current.isMoving() && !map.current.isZooming()) {
+      // Always apply bearing — don't gate on isMoving/isZooming since the
+      // user expects the map to track their heading continuously.
+      if (map.current) {
         map.current.jumpTo({ bearing: heading });
       }
     };
 
-    // Prefer 'deviceorientationabsolute' (Android Chrome) which gives
-    // compass-relative values.  Fall back to 'deviceorientation' (iOS,
-    // other browsers) which provides webkitCompassHeading on iOS.
-    const useAbsolute = 'ondeviceorientationabsolute' in window;
-    const eventName = useAbsolute
-      ? 'deviceorientationabsolute'
-      : 'deviceorientation';
+    // Listen to both event types when available.  Android Chrome fires
+    // 'deviceorientationabsolute' with compass-relative alpha; iOS fires
+    // 'deviceorientation' with webkitCompassHeading.  If the device
+    // supports absolute, also listen to the standard event as a fallback.
+    const events: string[] = [];
+    if ('ondeviceorientationabsolute' in window) {
+      events.push('deviceorientationabsolute');
+    }
+    events.push('deviceorientation');
 
-    window.addEventListener(eventName, handler as EventListener, true);
+    for (const evt of events) {
+      window.addEventListener(evt, handler as EventListener);
+    }
     compassCleanup.current = () => {
-      window.removeEventListener(eventName, handler as EventListener, true);
+      for (const evt of events) {
+        window.removeEventListener(evt, handler as EventListener);
+      }
     };
     setCompassMode(true);
   };

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -48,6 +48,7 @@ import {
   updateRideLayer,
   removeRideLayer,
   detectTrailAtPoint,
+  toLngLatBounds,
 } from '@/utils/map';
 import { loadRide } from '@/utils/ride-storage';
 import { mapConfig } from '@/config/map.config';
@@ -338,13 +339,7 @@ const MapboxMap = memo(function MapboxMap() {
 
       // Fall back to defaultBounds when runtime bounds aren't available
       const bounds =
-        selectedRoute?.bounds ??
-        (selectedRoute?.defaultBounds
-          ? new mapboxgl.LngLatBounds(
-              [selectedRoute.defaultBounds[0], selectedRoute.defaultBounds[1]],
-              [selectedRoute.defaultBounds[2], selectedRoute.defaultBounds[3]],
-            )
-          : undefined);
+        selectedRoute?.bounds ?? toLngLatBounds(selectedRoute?.defaultBounds);
 
       if (bounds) {
         flyToBounds(map.current, bounds);
@@ -387,14 +382,7 @@ const MapboxMap = memo(function MapboxMap() {
 
       // Fall back to defaultBounds when runtime bounds aren't available
       // (e.g. trail tiles not loaded for the current viewport)
-      const bounds =
-        trail?.bounds ??
-        (trail?.defaultBounds
-          ? new mapboxgl.LngLatBounds(
-              [trail.defaultBounds[0], trail.defaultBounds[1]],
-              [trail.defaultBounds[2], trail.defaultBounds[3]],
-            )
-          : undefined);
+      const bounds = trail?.bounds ?? toLngLatBounds(trail?.defaultBounds);
 
       // Skip flyToBounds for auto-detected trails (map already follows user)
       if (!autoDetected && bounds) {
@@ -987,7 +975,10 @@ const MapboxMap = memo(function MapboxMap() {
             console.error('Map error:', event.error);
           });
 
-          // Signal that the map is fully initialized and ready for events
+          // Signal that the map is fully initialized and ready for events.
+          // Set a flag first so late listeners (e.g. page.tsx useEffect that
+          // registers after this fires) can detect they missed the event.
+          (window as unknown as Record<string, boolean>).__mapReady = true;
           window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
         } catch (error) {
           console.error('Error initializing map:', error);
@@ -1053,13 +1044,27 @@ const MapboxMap = memo(function MapboxMap() {
           .catch(() => {});
       }
 
-      // When enabled: immediately center on current location (preserving zoom)
+      // When enabled: immediately center on current location (preserving zoom).
+      // If GPS hasn't fired yet (locationMarker null), wait for the first
+      // LOCATION_UPDATE and then fly there — fixes iOS cold-start delay.
       if (map.current && locationMarker.current) {
         const lngLat = locationMarker.current.getLngLat();
         map.current.flyTo({
           center: [lngLat.lng, lngLat.lat],
           essential: true,
           duration: 1000,
+        });
+      } else if (map.current) {
+        const onFirstLocation = (e: Event) => {
+          const { lng, lat } = (e as CustomEvent).detail;
+          map.current?.flyTo({
+            center: [lng, lat],
+            essential: true,
+            duration: 1000,
+          });
+        };
+        window.addEventListener(MAP_EVENTS.LOCATION_UPDATE, onFirstLocation, {
+          once: true,
         });
       }
 
@@ -1144,6 +1149,15 @@ const MapboxMap = memo(function MapboxMap() {
         heading = (360 - e.alpha) % 360;
       }
       if (heading === null) return;
+
+      // Skip tiny changes (< 2°) to avoid excessive jumpTo calls (~60 Hz)
+      const prev = compassHeading.current;
+      if (
+        prev !== null &&
+        Math.abs(heading - prev) < 2 &&
+        Math.abs(heading - prev) < 358
+      )
+        return;
 
       compassHeading.current = heading;
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1133,8 +1133,7 @@ const MapboxMap = memo(function MapboxMap() {
   // phone is held upright (gimbal lock region).
   const attachCompassListener = () => {
     // Low-pass filter weight: 0 = ignore new readings, 1 = no smoothing.
-    // 0.08 gives a smooth ~300ms response while damping jitter on iOS.
-    const SMOOTHING = 0.08;
+    const SMOOTHING = 0.2;
     let smoothed: number | null = null;
 
     const handler = (e: DeviceOrientationEvent) => {
@@ -1173,7 +1172,7 @@ const MapboxMap = memo(function MapboxMap() {
       if (map.current) {
         map.current.easeTo({
           bearing: smoothed,
-          duration: 100,
+          duration: 50,
           easing: (t) => t,
         });
       }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1120,8 +1120,8 @@ const MapboxMap = memo(function MapboxMap() {
           duration: 500,
         });
       }
-      // Release wake lock
-      if (wakeLock.current) {
+      // Keep wake lock alive during recording so the screen stays on
+      if (!recordingActive.current && wakeLock.current) {
         wakeLock.current.release();
         wakeLock.current = null;
       }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -798,14 +798,14 @@ const MapboxMap = memo(function MapboxMap() {
             });
           });
 
-          // Find the first symbol/label layer — route lines will be
-          // inserted below it so street names remain visible on top.
+          // Find the road-label layer — route lines will be inserted
+          // just below it so street names remain visible on top of routes.
           const style = newMap.getStyle();
-          let firstSymbolId: string | undefined;
+          let firstLabelId: string | undefined;
           if (style?.layers) {
             for (const l of style.layers) {
-              if (l.type === 'symbol') {
-                firstSymbolId = l.id;
+              if (l.id === 'road-label') {
+                firstLabelId = l.id;
                 break;
               }
             }
@@ -827,9 +827,9 @@ const MapboxMap = memo(function MapboxMap() {
                   newMap.setLayoutProperty(layer.id, 'line-cap', 'round');
                   newMap.setLayoutProperty(layer.id, 'line-join', 'round');
 
-                  // Move route layer below labels so street names show
-                  if (firstSymbolId) {
-                    newMap.moveLayer(layer.id, firstSymbolId);
+                  // Move route layer below road labels so street names show
+                  if (firstLabelId) {
+                    newMap.moveLayer(layer.id, firstLabelId);
                   }
 
                   // Add white casing layer beneath the route

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1133,8 +1133,8 @@ const MapboxMap = memo(function MapboxMap() {
   // phone is held upright (gimbal lock region).
   const attachCompassListener = () => {
     // Low-pass filter weight: 0 = ignore new readings, 1 = no smoothing.
-    // 0.15 gives a smooth ~200ms response while damping oscillation.
-    const SMOOTHING = 0.15;
+    // 0.08 gives a smooth ~300ms response while damping jitter on iOS.
+    const SMOOTHING = 0.08;
     let smoothed: number | null = null;
 
     const handler = (e: DeviceOrientationEvent) => {
@@ -1171,7 +1171,11 @@ const MapboxMap = memo(function MapboxMap() {
 
       compassHeading.current = smoothed;
       if (map.current) {
-        map.current.jumpTo({ bearing: smoothed });
+        map.current.easeTo({
+          bearing: smoothed,
+          duration: 100,
+          easing: (t) => t,
+        });
       }
     };
 

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -67,6 +67,9 @@ const MapboxMap = memo(function MapboxMap() {
   const locationWatch = useRef<NodeJS.Timeout | undefined>(undefined);
   const wakeLock = useRef<WakeLockSentinel | null>(null);
   const [watchingLocation, setWatchingLocation] = useState(false);
+  const [compassMode, setCompassMode] = useState(false);
+  const compassHeading = useRef<number | null>(null);
+  const compassCleanup = useRef<(() => void) | null>(null);
   const recordingActive = useRef(false);
 
   // Track markers for attractions and bike resources
@@ -286,6 +289,12 @@ const MapboxMap = memo(function MapboxMap() {
     const disableTracking = () => {
       if (recordingActive.current) return;
       setWatchingLocation(false);
+      setCompassMode(false);
+      if (compassCleanup.current) {
+        compassCleanup.current();
+        compassCleanup.current = null;
+      }
+      compassHeading.current = null;
       if (locationWatch.current) {
         clearInterval(locationWatch.current);
         locationWatch.current = undefined;
@@ -1065,15 +1074,33 @@ const MapboxMap = memo(function MapboxMap() {
         }
 
         const lngLat = locationMarker.current.getLngLat();
-        map.current.jumpTo({
+        const jumpOpts: mapboxgl.CameraOptions = {
           center: [lngLat.lng, lngLat.lat],
-        });
+        };
+        // In compass mode, rotate the map to match device heading
+        if (compassHeading.current !== null) {
+          jumpOpts.bearing = compassHeading.current;
+        }
+        map.current.jumpTo(jumpOpts);
       }, 1000);
     } else {
-      // When disabled: stop tracking
+      // When disabled: stop tracking and compass
       if (locationWatch.current) {
         clearInterval(locationWatch.current);
         locationWatch.current = undefined;
+      }
+      if (compassCleanup.current) {
+        compassCleanup.current();
+        compassCleanup.current = null;
+      }
+      compassHeading.current = null;
+      setCompassMode(false);
+      // Reset bearing to default
+      if (map.current) {
+        map.current.easeTo({
+          bearing: mapConfig.defaultView.bearing,
+          duration: 500,
+        });
       }
       // Release wake lock
       if (wakeLock.current) {
@@ -1083,9 +1110,57 @@ const MapboxMap = memo(function MapboxMap() {
     }
   };
 
-  // Toggle location tracking
+  // Start compass (device orientation) to rotate the map bearing
+  const startCompass = async () => {
+    // iOS 13+ requires explicit permission
+    const DOE = DeviceOrientationEvent as unknown as {
+      requestPermission?: () => Promise<string>;
+    };
+    if (DOE.requestPermission) {
+      try {
+        const permission = await DOE.requestPermission();
+        if (permission !== 'granted') return;
+      } catch {
+        return;
+      }
+    }
+
+    const handler = (e: DeviceOrientationEvent) => {
+      // iOS provides webkitCompassHeading (degrees from north, clockwise)
+      // Android/standard uses alpha (degrees, counterclockwise from north)
+      const evt = e as DeviceOrientationEvent & {
+        webkitCompassHeading?: number;
+      };
+      let heading: number | null = null;
+      if (typeof evt.webkitCompassHeading === 'number') {
+        heading = evt.webkitCompassHeading;
+      } else if (typeof e.alpha === 'number' && e.absolute) {
+        heading = (360 - e.alpha) % 360;
+      }
+      if (heading !== null) {
+        compassHeading.current = heading;
+      }
+    };
+
+    window.addEventListener('deviceorientation', handler, true);
+    compassCleanup.current = () => {
+      window.removeEventListener('deviceorientation', handler, true);
+    };
+    setCompassMode(true);
+  };
+
+  // Toggle location tracking: off → tracking (north-up) → compass (heading-up) → off
   const toggleWatchLocation = () => {
-    setLocationWatch(!watchingLocation);
+    if (!watchingLocation) {
+      // off → tracking
+      setLocationWatch(true);
+    } else if (!compassMode) {
+      // tracking → compass
+      startCompass();
+    } else {
+      // compass → off
+      setLocationWatch(false);
+    }
   };
 
   // Enable location tracking when recording starts, disable when it stops
@@ -1159,24 +1234,48 @@ const MapboxMap = memo(function MapboxMap() {
           className={cn(
             'absolute bottom-[60px] right-4 w-10 h-10 rounded-full cursor-pointer z-[501] shadow-[0_2px_4px_rgba(0,0,0,0.2)] text-white flex items-center justify-center bg-white transition-colors duration-200 [&_svg]:w-5 active:bg-[#e5e5e5]',
             watchingLocation &&
+              !compassMode &&
               'bg-[rgb(165,240,255)] active:bg-[rgb(145,220,235)]',
+            compassMode && 'bg-[rgb(100,200,255)] active:bg-[rgb(80,180,235)]',
           )}
         >
-          <svg
-            viewBox="0 0 100 100"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-            role="img"
-            preserveAspectRatio="xMidYMid meet"
-            fill="#000000"
-          >
-            <g>
-              <path
-                d="M87.13 0a2.386 2.386 0 0 0-.64.088a2.386 2.386 0 0 0-.883.463L11.34 62.373a2.386 2.386 0 0 0 1.619 4.219l37.959-1.479l17.697 33.614a2.386 2.386 0 0 0 4.465-.707L89.486 2.79A2.386 2.386 0 0 0 87.131 0z"
+          {compassMode ? (
+            /* Compass icon for heading-up mode */
+            <svg
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              role="img"
+              fill="none"
+              stroke="#000000"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polygon
+                points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"
                 fill="#000000"
-              ></path>
-            </g>
-          </svg>
+              />
+            </svg>
+          ) : (
+            /* Navigation arrow for center/off mode */
+            <svg
+              viewBox="0 0 100 100"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              role="img"
+              preserveAspectRatio="xMidYMid meet"
+              fill="#000000"
+            >
+              <g>
+                <path
+                  d="M87.13 0a2.386 2.386 0 0 0-.64.088a2.386 2.386 0 0 0-.883.463L11.34 62.373a2.386 2.386 0 0 0 1.619 4.219l37.959-1.479l17.697 33.614a2.386 2.386 0 0 0 4.465-.707L89.486 2.79A2.386 2.386 0 0 0 87.131 0z"
+                  fill="#000000"
+                />
+              </g>
+            </svg>
+          )}
         </div>
       )}
     </>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -71,6 +71,7 @@ const MapboxMap = memo(function MapboxMap() {
   const [compassMode, setCompassMode] = useState(false);
   const compassHeading = useRef<number | null>(null);
   const compassCleanup = useRef<(() => void) | null>(null);
+  const pendingLocationListener = useRef<((e: Event) => void) | null>(null);
   const recordingActive = useRef(false);
 
   // Track markers for attractions and bike resources
@@ -1056,6 +1057,7 @@ const MapboxMap = memo(function MapboxMap() {
         });
       } else if (map.current) {
         const onFirstLocation = (e: Event) => {
+          pendingLocationListener.current = null;
           const { lng, lat } = (e as CustomEvent).detail;
           map.current?.flyTo({
             center: [lng, lat],
@@ -1063,6 +1065,7 @@ const MapboxMap = memo(function MapboxMap() {
             duration: 1000,
           });
         };
+        pendingLocationListener.current = onFirstLocation;
         window.addEventListener(MAP_EVENTS.LOCATION_UPDATE, onFirstLocation, {
           once: true,
         });
@@ -1095,6 +1098,14 @@ const MapboxMap = memo(function MapboxMap() {
       if (locationWatch.current) {
         clearInterval(locationWatch.current);
         locationWatch.current = undefined;
+      }
+      // Cancel pending GPS-first-fix listener so it doesn't flyTo after disable
+      if (pendingLocationListener.current) {
+        window.removeEventListener(
+          MAP_EVENTS.LOCATION_UPDATE,
+          pendingLocationListener.current,
+        );
+        pendingLocationListener.current = null;
       }
       if (compassCleanup.current) {
         compassCleanup.current();
@@ -1150,14 +1161,13 @@ const MapboxMap = memo(function MapboxMap() {
       }
       if (heading === null) return;
 
-      // Skip tiny changes (< 2°) to avoid excessive jumpTo calls (~60 Hz)
+      // Skip tiny changes (< 2°) to avoid excessive jumpTo calls (~60 Hz).
+      // The > 358 check handles wraparound (e.g. 359° → 1° is only 2°).
       const prev = compassHeading.current;
-      if (
-        prev !== null &&
-        Math.abs(heading - prev) < 2 &&
-        Math.abs(heading - prev) < 358
-      )
-        return;
+      if (prev !== null) {
+        const diff = Math.abs(heading - prev);
+        if (diff < 2 || diff > 358) return;
+      }
 
       compassHeading.current = heading;
 

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { MAP_EVENTS } from './events';
+
+describe('MAP_EVENTS', () => {
+  it('includes MAP_READY event', () => {
+    expect(MAP_EVENTS.MAP_READY).toBe('map-ready');
+  });
+
+  it('has unique event names', () => {
+    const values = Object.values(MAP_EVENTS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -18,4 +18,5 @@ export const MAP_EVENTS = {
   RIDE_DESELECT: 'ride-deselect',
   RIDES_PANEL_TOGGLE: 'rides-panel-toggle',
   TOAST: 'toast',
+  MAP_READY: 'map-ready',
 } as const;

--- a/src/utils/map.test.ts
+++ b/src/utils/map.test.ts
@@ -9,6 +9,7 @@ import {
   highlightMtnBikeArea,
   initMtnBikeColors,
   detectTrailAtPoint,
+  toLngLatBounds,
   TRAIL_LAYERS,
 } from './map';
 import type { BikeRoute, MountainBikeTrail } from '@/data/geo_data';
@@ -852,5 +853,20 @@ describe('detectTrailAtPoint', () => {
 
     const result = detectTrailAtPoint(mockMap, [-85.3, 35.0]);
     expect(result).toBeNull();
+  });
+});
+
+describe('toLngLatBounds', () => {
+  it('returns undefined for undefined input', () => {
+    expect(toLngLatBounds(undefined)).toBeUndefined();
+  });
+
+  it('returns LngLatBounds for a valid tuple', () => {
+    const bounds = toLngLatBounds([-85.33, 35.03, -85.28, 35.06]);
+    expect(bounds).toBeDefined();
+    expect(bounds?.getWest()).toBeCloseTo(-85.33);
+    expect(bounds?.getSouth()).toBeCloseTo(35.03);
+    expect(bounds?.getEast()).toBeCloseTo(-85.28);
+    expect(bounds?.getNorth()).toBeCloseTo(35.06);
   });
 });

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -342,7 +342,7 @@ export function initMtnBikeLayers(map: mapboxgl.Map): void {
         },
         paint: {
           'line-color': 'rgba(0,0,0,0)',
-          'line-width': 20,
+          'line-width': 10,
           'line-opacity': 0,
         },
       });

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -149,6 +149,15 @@ export function calculateTrailBounds(
   return null;
 }
 
+/** Convert a [swLng, swLat, neLng, neLat] tuple to LngLatBounds, or return undefined. */
+export function toLngLatBounds(
+  defaultBounds: [number, number, number, number] | undefined,
+): mapboxgl.LngLatBounds | undefined {
+  if (!defaultBounds) return undefined;
+  const [swLng, swLat, neLng, neLat] = defaultBounds;
+  return new mapboxgl.LngLatBounds([swLng, swLat], [neLng, neLat]);
+}
+
 export function initTrailBoundsFromDefaults(trails: MountainBikeTrail[]): void {
   for (const trail of trails) {
     if (!trail.bounds && trail.defaultBounds) {

--- a/src/utils/ride-stats.test.ts
+++ b/src/utils/ride-stats.test.ts
@@ -211,6 +211,31 @@ describe('computeElevation', () => {
     expect(max).toBeLessThanOrEqual(200);
     expect(max).toBeGreaterThan(min);
   });
+
+  it('filters GPS jitter below the dead-band threshold', () => {
+    // Simulate noisy GPS: altitude oscillates ±1m around 200m.
+    // Real elevation is flat, so gain and loss should be 0.
+    const points: RidePoint[] = Array.from({ length: 50 }, (_, i) => ({
+      lng: -85.3 + i * 0.0001,
+      lat: 35.05 + i * 0.0001,
+      altitude: 200 + (i % 2 === 0 ? 1 : -1),
+      accuracy: 5,
+      speed: 5,
+      timestamp: 1700000000000 + i * 1000,
+    }));
+    const { gain, loss } = computeElevation(points);
+    expect(gain).toBe(0);
+    expect(loss).toBe(0);
+  });
+
+  it('counts genuine climbs that exceed the dead band', () => {
+    // 20 points climbing 5m each = 95m total climb, well above threshold
+    const points = makeTrack(20, { startAlt: 100, altStep: 5 });
+    const { gain, loss } = computeElevation(points);
+    // After smoothing + dead-band, gain should still capture most of the climb
+    expect(gain).toBeGreaterThan(50);
+    expect(loss).toBe(0);
+  });
 });
 
 // --- computeMaxSpeed ---

--- a/src/utils/ride-stats.ts
+++ b/src/utils/ride-stats.ts
@@ -25,6 +25,10 @@ const STOP_DURATION_MS = 10_000;
 const MAX_PLAUSIBLE_SPEED = 30;
 // Smoothing window for elevation (points on each side)
 const ELEVATION_SMOOTH_WINDOW = 2;
+// Dead-band threshold for elevation gain/loss (meters).  Accumulated
+// elevation change must exceed this before it counts as gain or loss.
+// Filters GPS altitude jitter that otherwise inflates totals ~3-4×.
+const ELEVATION_DEAD_BAND = 3;
 
 export function haversineDistance(
   lat1: number,
@@ -142,18 +146,27 @@ export function computeElevation(points: AnyRidePoint[]): {
   let loss = 0;
   let min = Infinity;
   let max = -Infinity;
-  let prevValid: number | null = null;
+
+  // Dead-band accumulator: track the last "committed" altitude and
+  // only count gain/loss once the change exceeds the threshold.
+  let anchor: number | null = null;
 
   for (const alt of smoothed) {
     if (Number.isNaN(alt)) continue;
     if (alt < min) min = alt;
     if (alt > max) max = alt;
-    if (prevValid !== null) {
-      const delta = alt - prevValid;
-      if (delta > 0) gain += delta;
-      else loss += Math.abs(delta);
+    if (anchor === null) {
+      anchor = alt;
+      continue;
     }
-    prevValid = alt;
+    const delta = alt - anchor;
+    if (delta > ELEVATION_DEAD_BAND) {
+      gain += delta;
+      anchor = alt;
+    } else if (delta < -ELEVATION_DEAD_BAND) {
+      loss += Math.abs(delta);
+      anchor = alt;
+    }
   }
 
   if (min === Infinity) min = 0;


### PR DESCRIPTION
## Summary
- **Fix #59** — Share links (`?trail=…` / `?route=…`) wait for `MAP_READY` event instead of a 2s timeout. Falls back to `defaultBounds` when runtime bounds aren't available.
- **Fix #57** — Skip `jumpTo` during `isMoving()`/`isZooming()` to prevent zoom snap-back. Allow panning during recording (pauses auto-center, keeps wake lock).
- **Fix #58** — Compass mode: 3-state location button (off → tracking → compass → off). Low-pass filtered heading with `easeTo` for smooth rotation. iOS permission in gesture context, Android `deviceorientationabsolute` support.
- **Elevation** — 3m dead-band threshold on `computeElevation` filters GPS altitude jitter (was inflating gain/loss ~3.5× vs Strava).
- **Wake lock** — No longer released when toggling tracking off during an active recording.
- **Layer ordering** — Route lines moved below `road-label` so street names are visible on top.
- **Trail detection** — Hit-test width 20→10px and confirmation thresholds raised (3/5 hits) to reduce false matches.

## Test plan
- [x] Share link `?trail=mouse-creek-greenway-phase-1` loads and zooms to the trail
- [x] Share link `?route=zoo-loop` loads and zooms to the route
- [x] Pinch-to-zoom during recording sticks (iOS + Android)
- [ ] Drag map during recording pauses auto-center; tap location button to resume
- [ ] Location button: tap 1 = center, tap 2 = compass (map rotates with device), tap 3 = off
- [ ] Compass is smooth on iOS, no jitter when phone is upright on Android
- [ ] Elevation gain/loss on a recorded ride is reasonable (not 3× inflated)
- [ ] Screen stays awake during recording even after toggling tracking
- [ ] Street names visible on top of route lines
- [ ] Trail auto-detect doesn't match nearby trails you're not on

🤖 Generated with [Claude Code](https://claude.com/claude-code)