### PR TITLE
Misc fixes: route colors, distance/elevation in sidebar, shop updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yarn-error.log*
 .auth/
 .env.test
 scripts/.tile_cache/
+
+# scratch / local-only files
+tmp/

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@/data/geo_data', () => ({
     {
       id: 'zoo-loop-v2-full-public',
       name: 'Zoo Loop',
-      color: '#DC2626',
+      color: '#F97316',
       description: 'Zoo route',
       defaultWidth: 8,
       opacity: 1.0,

--- a/src/components/MapMarkers.tsx
+++ b/src/components/MapMarkers.tsx
@@ -193,18 +193,9 @@ export function createAttractionMarker(feature: MapFeature): mapboxgl.Marker {
 export function createBikeResourceMarker(
   resource: BikeResource,
 ): mapboxgl.Marker {
-  // Get icon class - default to bicycle
-  let iconClass = 'fa-bicycle';
-
-  if (resource.icon?.iconName) {
-    // Automatically construct the FontAwesome class from the icon name
-    iconClass = `fa-${resource.icon.iconName}`;
-  }
-
-  // Create element
   const el = createMarkerElement(
     'map-marker bike-marker',
-    iconClass,
+    'fa-bicycle',
     '#34d399',
   );
 

--- a/src/components/sidebar/BikeResourcesList.tsx
+++ b/src/components/sidebar/BikeResourcesList.tsx
@@ -1,3 +1,4 @@
+import { faBicycle } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/lib/utils';
 import { bikeResources } from '@/data/geo_data';
 import { SidebarCard } from './SidebarCard';
@@ -15,7 +16,7 @@ export function BikeResourcesList({
           <SidebarCard
             key={location.name}
             colorTheme="green"
-            icon={location.icon}
+            icon={faBicycle}
             title={location.name}
             description={location.description}
             onClick={() => onCenterLocation(location)}

--- a/src/components/sidebar/BikeRoutes.tsx
+++ b/src/components/sidebar/BikeRoutes.tsx
@@ -32,11 +32,9 @@ export function BikeRoutes({ selectedRoute, onRouteSelect }: BikeRoutesProps) {
               style={{ backgroundColor: route.color }}
             />
             <span className="font-medium">{route.name}</span>
-            {route.distance ? (
-              <span className="text-[11px] text-gray-500 ml-auto shrink-0">
-                {route.distance} mi
-              </span>
-            ) : null}
+            <span className="text-[11px] text-gray-500 ml-auto shrink-0">
+              {route.distance} mi
+            </span>
           </div>
           <div className="text-xs text-gray-500 mt-1 ml-7">
             {route.description}

--- a/src/components/sidebar/BikeRoutes.tsx
+++ b/src/components/sidebar/BikeRoutes.tsx
@@ -32,6 +32,11 @@ export function BikeRoutes({ selectedRoute, onRouteSelect }: BikeRoutesProps) {
               style={{ backgroundColor: route.color }}
             />
             <span className="font-medium">{route.name}</span>
+            {route.distance ? (
+              <span className="text-[11px] text-gray-500 ml-auto shrink-0">
+                {route.distance} mi
+              </span>
+            ) : null}
           </div>
           <div className="text-xs text-gray-500 mt-1 ml-7">
             {route.description}

--- a/src/components/sidebar/ElevationProfile.tsx
+++ b/src/components/sidebar/ElevationProfile.tsx
@@ -16,7 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faDownload,
   faShareAlt,
-  faMountain,
+  faChartArea,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/lib/utils';
@@ -35,7 +35,7 @@ const MAX_GRADIENT_STOPS = 200;
 const CHART_SVG_CLASS =
   'w-full h-[15vh] min-h-[80px] max-h-[160px] cursor-crosshair rounded touch-none';
 const ACTION_BTN_CLASS =
-  'bg-transparent border-none cursor-pointer text-gray-400 text-xs px-1.5 py-0.5 rounded hover:text-gray-600 hover:bg-gray-50';
+  'bg-transparent border-none cursor-pointer text-gray-400 text-2xl px-2 py-1 rounded hover:text-gray-600 hover:bg-gray-50';
 
 export function gradeToColor(grade: number): string {
   const g = Math.min(Math.abs(grade), GRADE_RED);
@@ -484,7 +484,7 @@ export function ElevationProfile() {
           type="button"
           title="Show elevation profile"
         >
-          <FontAwesomeIcon icon={faMountain} className={TOGGLE_ICON_CLASS} />
+          <FontAwesomeIcon icon={faChartArea} className={TOGGLE_ICON_CLASS} />
         </button>
       </div>
     );

--- a/src/components/sidebar/RideHistory.tsx
+++ b/src/components/sidebar/RideHistory.tsx
@@ -15,6 +15,7 @@ import {
   formatDurationShort,
   formatDate,
   formatBytes,
+  formatElevation,
 } from '@/utils/format';
 import { cn } from '@/lib/utils';
 import { RideDetail } from './RideDetail';
@@ -136,6 +137,9 @@ export function RideHistory({
             {formatDate(s.startTime)} &middot;{' '}
             {formatDistance(s.stats.distance)} &middot;{' '}
             {formatDurationShort(s.stats.elapsedTime)}
+            {s.stats.elevationGain > 0 && (
+              <> &middot; &uarr;{formatElevation(s.stats.elevationGain)}</>
+            )}
           </div>
         </div>
       ))}

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -3,7 +3,7 @@ import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 export interface LocationProps {
   name: string;
   description: string;
-  icon: IconDefinition;
+  icon?: IconDefinition;
   latitude?: number;
   longitude?: number;
   address?: string;

--- a/src/data/bike-resources.ts
+++ b/src/data/bike-resources.ts
@@ -1,9 +1,5 @@
 import {
-  faMountain,
   faBicycle,
-  faRoad,
-  faBolt,
-  faHandsHelping,
   type IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 
@@ -24,7 +20,7 @@ export const bikeResources: BikeResource[] = [
     address: '630 W Bell Avenue, Chattanooga, TN 37405',
     latitude: 35.0735,
     longitude: -85.3188,
-    icon: faMountain,
+    icon: faBicycle,
   },
   {
     name: 'East Ridge Bicycles',
@@ -39,10 +35,10 @@ export const bikeResources: BikeResource[] = [
     name: 'Trek Bicycle Store',
     description:
       'Official retailer offering a range of Trek bikes, accessories, and professional maintenance services.',
-    address: '307 Manufacturers Road, Suite 117, Chattanooga, TN 37405',
-    latitude: 35.0524,
-    longitude: -85.3108,
-    icon: faRoad,
+    address: '307 Manufacturers Rd #117, Chattanooga, TN 37405',
+    latitude: 35.0628386,
+    longitude: -85.3138755,
+    icon: faBicycle,
   },
   {
     name: 'Chatt eBikes',
@@ -51,7 +47,7 @@ export const bikeResources: BikeResource[] = [
     address: '1404 McCallie Avenue, Suite 102, Chattanooga, TN 37404',
     latitude: 35.03825275443797,
     longitude: -85.28125452877657,
-    icon: faBolt,
+    icon: faBicycle,
   },
   {
     name: 'Two Bikes Chattanooga',
@@ -60,7 +56,7 @@ export const bikeResources: BikeResource[] = [
     address: '1810 E. Main Street, Suite 100, Chattanooga, TN 37404',
     latitude: 35.026111,
     longitude: -85.281111,
-    icon: faHandsHelping,
+    icon: faBicycle,
   },
   {
     name: 'Loblolly Bike Shop',
@@ -69,7 +65,16 @@ export const bikeResources: BikeResource[] = [
     address: '191 River St, Chattanooga, TN 37405',
     latitude: 35.0625,
     longitude: -85.3077,
-    icon: faBolt,
+    icon: faBicycle,
+  },
+  {
+    name: 'Mountaintown Bicycles',
+    description:
+      'Certified dealer offering an extensive selection of new bicycles and e-bikes with professional repair services.',
+    address: '5337 Ringgold Road, Chattanooga, TN 37412',
+    latitude: 34.9949081,
+    longitude: -85.2322395,
+    icon: faBicycle,
   },
   {
     name: 'Owen Cyclery',

--- a/src/data/bike-resources.ts
+++ b/src/data/bike-resources.ts
@@ -1,15 +1,9 @@
-import {
-  faBicycle,
-  type IconDefinition,
-} from '@fortawesome/free-solid-svg-icons';
-
 export interface BikeResource {
   name: string;
   description: string;
   address: string;
   latitude: number;
   longitude: number;
-  icon: IconDefinition;
 }
 
 export const bikeResources: BikeResource[] = [
@@ -20,7 +14,6 @@ export const bikeResources: BikeResource[] = [
     address: '630 W Bell Avenue, Chattanooga, TN 37405',
     latitude: 35.0735,
     longitude: -85.3188,
-    icon: faBicycle,
   },
   {
     name: 'East Ridge Bicycles',
@@ -29,7 +22,6 @@ export const bikeResources: BikeResource[] = [
     address: '5910 Ringgold Road, Chattanooga, TN 37412',
     latitude: 34.9899,
     longitude: -85.1992,
-    icon: faBicycle,
   },
   {
     name: 'Trek Bicycle Store',
@@ -38,7 +30,6 @@ export const bikeResources: BikeResource[] = [
     address: '307 Manufacturers Rd #117, Chattanooga, TN 37405',
     latitude: 35.0628386,
     longitude: -85.3138755,
-    icon: faBicycle,
   },
   {
     name: 'Chatt eBikes',
@@ -47,7 +38,6 @@ export const bikeResources: BikeResource[] = [
     address: '1404 McCallie Avenue, Suite 102, Chattanooga, TN 37404',
     latitude: 35.03825275443797,
     longitude: -85.28125452877657,
-    icon: faBicycle,
   },
   {
     name: 'Two Bikes Chattanooga',
@@ -56,7 +46,6 @@ export const bikeResources: BikeResource[] = [
     address: '1810 E. Main Street, Suite 100, Chattanooga, TN 37404',
     latitude: 35.026111,
     longitude: -85.281111,
-    icon: faBicycle,
   },
   {
     name: 'Loblolly Bike Shop',
@@ -65,7 +54,6 @@ export const bikeResources: BikeResource[] = [
     address: '191 River St, Chattanooga, TN 37405',
     latitude: 35.0625,
     longitude: -85.3077,
-    icon: faBicycle,
   },
   {
     name: 'Mountaintown Bicycles',
@@ -74,7 +62,6 @@ export const bikeResources: BikeResource[] = [
     address: '5337 Ringgold Road, Chattanooga, TN 37412',
     latitude: 34.9949081,
     longitude: -85.2322395,
-    icon: faBicycle,
   },
   {
     name: 'Owen Cyclery',
@@ -83,6 +70,5 @@ export const bikeResources: BikeResource[] = [
     address: '1920 Northpoint Blvd, Hixson, TN 37343',
     latitude: 35.126,
     longitude: -85.249,
-    icon: faBicycle,
   },
 ];

--- a/src/data/bike-routes.ts
+++ b/src/data/bike-routes.ts
@@ -31,7 +31,7 @@ export const bikeRoutes: BikeRoute[] = [
   {
     id: 'zoo-loop-v2-full-public',
     name: 'Zoo Loop',
-    color: '#DC2626',
+    color: '#F97316',
     description:
       'Fun route through the university to visit the zoo and a nearby park. Moderate traffic.',
     icon: faRoute,
@@ -77,7 +77,7 @@ export const bikeRoutes: BikeRoute[] = [
   {
     id: 'Moccasin Bend Route',
     name: 'Moccasin Bend Route',
-    color: '#F97316',
+    color: '#DC2626',
     description: 'Scenic route around Moccasin Bend with river views.',
     icon: faRoute,
     defaultWidth: 8,


### PR DESCRIPTION
## Summary

Bundles three small issues plus a tooling cleanup.

**Closes #76 — swap Zoo Loop ↔ Moccasin Bend colors**
Match the painted trail signs: Zoo Loop is now orange, Moccasin Bend is red.

**Closes #74 — show route length and ride elevation**
- Bike routes show distance in miles next to the name (matches the MTB row layout).
- Recorded rides show elevation gain in the existing date · distance · time line.
- Did **not** generate per-route elevation profile JSONs — that's a bigger follow-up if you want full charts for routes.

**Closes #70 — shop and elevation panel updates**
- Add Mountaintown Bicycles (5337 Ringgold Rd).
- Unify all bike shop markers to `faBicycle` per @lsoules' note.
- Correct Trek Bicycle Store coordinates (was off — see linked map in issue).
- Swap the elevation-profile collapsed-state icon from `faMountain` → `faChartArea`.
- Double the size of the elevation panel's share / download / close buttons (`text-xs` → `text-2xl`).
- "Chatt eBikes" rename was already applied in current data.
- Loblolly is already in the data — left unchanged pending clarification on what to update.

**Tooling**
- Add `tmp/` to `.gitignore` for local scratch files.

## Test plan

- [ ] Visit the app, open the sidebar
  - [ ] Each casual route row shows `<n.n> mi` on the right
  - [ ] Zoo Loop swatch is orange; Moccasin Bend swatch is red
  - [ ] All bike shop markers use the same bicycle icon (no mountain/road/bolt/hands-helping mix)
- [ ] Click a trail or open a recorded ride to surface the elevation panel
  - [ ] Collapse it — toggle button shows the chart-area icon, not a mountain
  - [ ] Share / download / close buttons are visibly larger (~2x)
- [ ] Open a recorded ride in the rides list — row shows `↑<n> ft` after the existing date · distance · time
- [ ] Search the map for Mountaintown Bicycles — pin appears at 5337 Ringgold Rd
- [ ] Trek Bicycle Store pin sits on its actual storefront (not the prior offset location)