### PR TITLE
Rewrite README as general-purpose trail/bike platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Open Bike Map
 
+<p align="center">
+  <a href="https://bikechatt.com">
+    <img src="https://img.shields.io/badge/%E2%96%B6%20Live%20Demo-bikechatt.com-2563EB?style=for-the-badge&labelColor=111827" alt="Live Demo: bikechatt.com" height="48">
+  </a>
+</p>
+
 An open-source trail and bike-route platform for any community. Browse curated road and greenway routes, hundreds of mountain bike trails with elevation profiles, real-time bike share availability, and record your own rides with GPS — all in a fast, mobile-first web app you can install to your home screen.
 
-The Chattanooga, TN deployment is the reference implementation. The codebase is built so a new community can fork it, swap configuration and data, and ship.
+The included reference deployment is configured for [Chattanooga, TN](https://bikechatt.com), but the codebase is built so a new community can fork it, swap configuration and data, and ship.
 
 <p align="center">
   <img src="public/screenshot-splash.png" alt="Open Bike Map main view" width="45%">
@@ -20,14 +26,14 @@ Open Bike Map is designed to be re-skinned for a new community in an afternoon, 
 - **Bring-your-own bike share (or skip it).** If your city publishes a [GBFS](https://gbfs.org/) feed, change one URL. If it doesn't, hide the layer.
 - **Brand it.** Replace logos in `public/`, swap the welcome copy in `WelcomeModal.tsx`, adjust the brand colors in `tailwind.config.ts` (`app-primary` / `app-secondary`).
 
-A community fork is a fork-and-edit, not a rewrite. The Chattanooga build is just one set of inputs to a generic engine — see [Deploying for your community](#deploying-for-your-community) below for the step-by-step.
+A community fork is a fork-and-edit, not a rewrite. The included build is just one set of inputs to a generic engine — see [Deploying for your community](#deploying-for-your-community) below for the step-by-step.
 
 ## Features
 
 ### For riders
 
 - **Curated bike routes** — Hand-picked road, greenway, and connector routes styled in Mapbox Studio with descriptions, distance, and zoom-to-fit bounds.
-- **Mountain bike trails** — 225+ trails in the Chattanooga deployment, grouped by recreation area and region, color-coded by difficulty, with per-trail elevation profiles (gain/loss/min/max and a sampled distance-vs-elevation chart).
+- **Mountain bike trails** — 225+ trails in the reference deployment, grouped by recreation area and region, color-coded by difficulty, with per-trail elevation profiles (gain/loss/min/max and a sampled distance-vs-elevation chart).
 - **Real-time bike share** — Live station availability via the [GBFS](https://gbfs.org/) standard, configurable per region.
 - **Points of interest** — Attractions, bike shops, rentals, and local resources as toggleable map layers.
 - **Live location & compass** — Tracks position and heading, with a smoothed compass heading derived from GPS readings.
@@ -77,7 +83,7 @@ src/
 ├── config/map.config.ts   Geo-specific configuration (Mapbox, GBFS, region)
 ├── data/
 │   ├── bike-routes.ts             Curated road/greenway routes
-│   ├── mountain-bike-trails.ts    Trail manifest (225+ in Chattanooga)
+│   ├── mountain-bike-trails.ts    Trail manifest (225+ in the reference build)
 │   ├── bike-resources.ts          Shops & repair stations
 │   ├── local-resources.ts         Community resources
 │   ├── map-features.ts            Attractions / POIs
@@ -98,7 +104,7 @@ scripts/                   Python tooling for trails & elevation
 
 ### Configuration model
 
-Everything geography-specific lives in `src/config/map.config.ts`. The Chattanooga config is the reference; a new community ships by:
+Everything geography-specific lives in `src/config/map.config.ts`. The included config is the reference; a new community ships by:
 
 1. Replacing the Mapbox style URL and access token (or sourcing them from env).
 2. Updating `defaultView` (center/zoom/pitch/bearing) for the area you want to land on.
@@ -202,7 +208,7 @@ The plan is to ship a thin native wrapper around the existing web app — most l
 
 What the wrapper buys us beyond the PWA:
 
-- **Discoverability** in the platform stores so a community deployment shows up for "Chattanooga bike map" searches.
+- **Discoverability** in the platform stores so a community deployment shows up for "[your city] bike map" searches.
 - **Better background GPS** for long rides, where mobile browsers throttle or suspend `geolocation` watchers.
 - **More reliable wake lock** and screen-on behavior across devices.
 - **Native share sheets** for exporting GPX rides into Strava, Komoot, etc.
@@ -233,7 +239,7 @@ This project is dedicated to the memory of our friend and collaborator Yoseph. I
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+GNU GPL v3 — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 
@@ -244,4 +250,4 @@ MIT — see [LICENSE](LICENSE).
 
 ---
 
-Made with ❤️ in Chattanooga, TN — and ready for your community next.
+Built for community trail networks, everywhere.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-# BikeMap
+# Open Bike Map
 
 An open-source trail and bike-route platform for any community. Browse curated road and greenway routes, hundreds of mountain bike trails with elevation profiles, real-time bike share availability, and record your own rides with GPS — all in a fast, mobile-first web app you can install to your home screen.
 
 The Chattanooga, TN deployment is the reference implementation. The codebase is built so a new community can fork it, swap configuration and data, and ship.
 
 <p align="center">
-  <img src="public/screenshot-splash.png" alt="BikeMap main view" width="45%">
+  <img src="public/screenshot-splash.png" alt="Open Bike Map main view" width="45%">
   <img src="public/screenshot-route.png" alt="Route selection view" width="45%">
 </p>
+
+## Make it yours
+
+Open Bike Map is designed to be re-skinned for a new community in an afternoon, not a quarter. Every piece a community would want to control is intentionally pulled out of the code and into a small, well-marked set of files:
+
+- **One config file for your geography.** `src/config/map.config.ts` holds the Mapbox style, default map view, GBFS feed, and region metadata. Point it at your area and the map opens there.
+- **Plain TypeScript data, not a CMS.** Routes, mountain bike trails, attractions, bike shops, and local resources are typed arrays in `src/data/`. Add an entry, ship a PR — no database, no admin panel, no backend.
+- **Style your routes in Mapbox Studio.** Curate route lines visually, then reference the layer IDs from `bike-routes.ts`. Trails come from a vector tileset you control.
+- **Trail data is automated.** Drop your trail tileset in, run `scripts/add_trail_elevation.py`, and the script generates per-trail elevation profiles, distances, and bounding boxes from Mapbox Vector Tiles + Terrain-RGB. No manual GPX wrangling.
+- **Bring-your-own bike share (or skip it).** If your city publishes a [GBFS](https://gbfs.org/) feed, change one URL. If it doesn't, hide the layer.
+- **Brand it.** Replace logos in `public/`, swap the welcome copy in `WelcomeModal.tsx`, adjust the brand colors in `tailwind.config.ts` (`app-primary` / `app-secondary`).
+
+A community fork is a fork-and-edit, not a rewrite. The Chattanooga build is just one set of inputs to a generic engine — see [Deploying for your community](#deploying-for-your-community) below for the step-by-step.
 
 ## Features
 
@@ -174,6 +187,36 @@ The fastest path:
 4. Style your routes and trails in Mapbox Studio; update layer IDs in the data files.
 5. Run the trail elevation script if you have mountain bike trails.
 6. Deploy on any Node host. Vercel works out of the box.
+
+## Future work
+
+### Native app wrapper for the App Store and Google Play
+
+Open Bike Map is already a Progressive Web App — it installs to the home screen, runs offline-friendly via a service worker, requests GPS / wake-lock / motion permissions, and ships custom splash screens. PWA install covers the technical case well, but it doesn't match how most riders look for a bike app: they search the App Store or Google Play.
+
+The plan is to ship a thin native wrapper around the existing web app — most likely [Capacitor](https://capacitorjs.com/) — so the same codebase ships to:
+
+- **iOS App Store** (Capacitor → native iOS shell)
+- **Google Play** (Capacitor → native Android shell)
+- **Web** (the current PWA, unchanged)
+
+What the wrapper buys us beyond the PWA:
+
+- **Discoverability** in the platform stores so a community deployment shows up for "Chattanooga bike map" searches.
+- **Better background GPS** for long rides, where mobile browsers throttle or suspend `geolocation` watchers.
+- **More reliable wake lock** and screen-on behavior across devices.
+- **Native share sheets** for exporting GPX rides into Strava, Komoot, etc.
+- **Push notifications** down the road — trail-condition alerts, new-route announcements per community.
+- **Apple Maps / Google Maps deep links** for "navigate to this trailhead."
+
+The architectural bet here is that the web app stays the source of truth and the wrapper is mechanical. Each community deployment can then choose: PWA-only (free, instant) or store-listed (one-time native build pipeline per community brand).
+
+### Other things on the roadmap
+
+- **Multi-community switcher** — host several cities from one deployment by selecting `mapConfig` per route or subdomain.
+- **Trail conditions / closures** — community-curated overlay so locals can flag a trail as wet, closed, or rerouted.
+- **Cloud ride sync (opt-in)** — rides are local-only today; an optional account would let riders see history across devices.
+- **Heatmaps from recorded rides** — anonymized aggregate to surface which informal connectors riders actually use.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,142 +1,188 @@
-# Chattanooga Bike Map
+# BikeMap
 
-An interactive map showcasing bike routes, bike share stations, attractions, and bike resources in Chattanooga, TN. Built with love by [iFixit](https://www.ifixit.com) for the Chattanooga cycling community.
+An open-source trail and bike-route platform for any community. Browse curated road and greenway routes, hundreds of mountain bike trails with elevation profiles, real-time bike share availability, and record your own rides with GPS — all in a fast, mobile-first web app you can install to your home screen.
+
+The Chattanooga, TN deployment is the reference implementation. The codebase is built so a new community can fork it, swap configuration and data, and ship.
 
 <p align="center">
-  <img src="public/screenshot-splash.png" alt="Chattanooga Bike Map - Main View" width="45%">
-  <img src="public/screenshot-route.png" alt="Route Selection View" width="45%">
+  <img src="public/screenshot-splash.png" alt="BikeMap main view" width="45%">
+  <img src="public/screenshot-route.png" alt="Route selection view" width="45%">
 </p>
 
 ## Features
 
-- **Curated Bike Routes**: Explore popular routes including the Riverwalk Loop, Zoo Loop, and local greenways
-- **Real-time Bike Share Data**: Live availability for Chattanooga's bike share stations via GBFS API
-- **Points of Interest**: Discover attractions, bike shops, and local resources
-- **Mobile-First Design**: Optimized for on-the-go route planning with PWA support
-- **Interactive Map**: Powered by Mapbox with custom styling and route visualization
+### For riders
 
-## Data Sources
+- **Curated bike routes** — Hand-picked road, greenway, and connector routes styled in Mapbox Studio with descriptions, distance, and zoom-to-fit bounds.
+- **Mountain bike trails** — 225+ trails in the Chattanooga deployment, grouped by recreation area and region, color-coded by difficulty, with per-trail elevation profiles (gain/loss/min/max and a sampled distance-vs-elevation chart).
+- **Real-time bike share** — Live station availability via the [GBFS](https://gbfs.org/) standard, configurable per region.
+- **Points of interest** — Attractions, bike shops, rentals, and local resources as toggleable map layers.
+- **Live location & compass** — Tracks position and heading, with a smoothed compass heading derived from GPS readings.
+- **Welcome onboarding** — Asks new users whether they ride Casual (greenways/loops) or Mountain (singletrack) and tailors the default view.
+- **Installable PWA** — Manifest, service worker, custom splash screens, and an in-app install prompt for iOS and Android home-screen install.
+- **Mobile-first UI** — Collapsible sidebar, touch-friendly controls, and resize handling that reflows the map when the sidebar opens or closes.
 
-- **Bike Share Stations**: [Chattanooga Bike Share GBFS API](https://chattanooga.publicbikesystem.net/customer/ube/gbfs/v1/)
-- **Mapping**: [Mapbox GL JS](https://www.mapbox.com/mapbox-gljs)
-- **Bike Routes**: Custom curated routes from local cycling community
+### Ride recording
 
-## Getting Started
+A full GPS ride tracker, all client-side:
+
+- Start, pause, resume, and stop with live distance, elapsed time, and elevation gain.
+- Wake-lock support keeps the screen on during a ride.
+- Accuracy gating (`MAX_ACCURACY_M`) discards bad GPS fixes before they pollute stats.
+- Elevation smoothing via EMA + dead-band + spike filtering, then optional DEM correction against Mapbox Terrain-RGB tiles for clean elevation profiles.
+- **Crash recovery** — Rides are checkpointed to IndexedDB so a browser crash, accidental tab close, or backgrounded mobile app can be recovered on next load.
+- **Background-gap detection** — If GPS goes silent for too long (mobile backgrounding), recording pauses gracefully.
+- Rides are saved locally to IndexedDB. Browse history, view per-ride detail with the route drawn on the map and elevation chart, and export as **GPX**.
+
+### For curators / community maintainers
+
+- **Configurable map** — `src/config/map.config.ts` centralizes the Mapbox token, style URL, default view (center/zoom/pitch/bearing), GBFS endpoints, and region metadata. Forking for a new community starts here.
+- **Trail tooling (Python)** — Scripts to extract trail geometry from a Mapbox vector tileset and sample elevation from Terrain-RGB, producing per-trail JSON profiles and updating the trail manifest with distance, gain/loss, and bounds:
+  - `scripts/add_trail_bounds.py` — Recompute bounding boxes and lengths from raw layer coordinates.
+  - `scripts/add_trail_elevation.py` — Generate `public/data/elevation/{slug}.json` and update `src/data/mountain-bike-trails.ts`.
+  - `scripts/validate_trails.py` — Sanity-check the trail manifest.
+- **Bidirectional events** — Components communicate via custom DOM events (`route-select`, `layer-toggle`, `center-location`, `route-deselect`, `sidebar-toggle`), so clicking a route on the map syncs the sidebar and vice versa. See `src/events.ts`.
+- **GPX import/export** — Round-trip rides and routes via the standard GPX 1.1 format.
+
+## Architecture
+
+Built on Next.js App Router with Mapbox GL JS for rendering. The map canvas is dynamically imported with SSR disabled because Mapbox is browser-only.
+
+```
+src/
+├── app/                   Next.js App Router pages (map, about, export, test)
+├── components/
+│   ├── Map.tsx            Main map orchestrator (init, markers, custom events)
+│   ├── MapLegend.tsx      Sidebar container & state
+│   ├── MapMarkers.tsx     Marker factories and MarkerManager
+│   ├── RidesPanel.tsx     Ride recording controls and history
+│   ├── WelcomeModal.tsx   First-run onboarding & ride-style preference
+│   ├── PwaInstallPrompt   Install-to-home-screen prompt
+│   └── sidebar/           BikeRoutes, MountainBikeTrails, MapLayers,
+│                          AttractionsList, BikeRentalList, BikeResourcesList,
+│                          ElevationProfile, RideHistory, RideDetail, ...
+├── config/map.config.ts   Geo-specific configuration (Mapbox, GBFS, region)
+├── data/
+│   ├── bike-routes.ts             Curated road/greenway routes
+│   ├── mountain-bike-trails.ts    Trail manifest (225+ in Chattanooga)
+│   ├── bike-resources.ts          Shops & repair stations
+│   ├── local-resources.ts         Community resources
+│   ├── map-features.ts            Attractions / POIs
+│   ├── gbfs.ts                    Live bike share API integration
+│   └── ride.ts                    Recorded-ride types & helpers
+├── hooks/                 useRideRecording, useLocationTracking, useWakeLock,
+│                          useMapResize, useToast, use-mobile
+├── utils/                 ride-stats, ride-storage (IndexedDB), dem (Terrain-RGB
+│                          elevation correction), gpx, gpx-parser, compass,
+│                          format, settings, map (geocoding & bounds), svg
+├── events.ts              Custom DOM event constants
+└── lib/utils.ts           cn() — clsx + tailwind-merge
+
+public/data/elevation/     Per-trail elevation JSON
+public/terrain/            Local terrain assets
+scripts/                   Python tooling for trails & elevation
+```
+
+### Configuration model
+
+Everything geography-specific lives in `src/config/map.config.ts`. The Chattanooga config is the reference; a new community ships by:
+
+1. Replacing the Mapbox style URL and access token (or sourcing them from env).
+2. Updating `defaultView` (center/zoom/pitch/bearing) for the area you want to land on.
+3. Pointing `gbfs.baseUrl` at your local GBFS feed (or removing the bike-share layer if there is none).
+4. Replacing the data files in `src/data/` with your routes, trails, shops, and POIs.
+5. Re-running `scripts/add_trail_elevation.py` to generate elevation profiles for your trails.
+
+The trail layer in Mapbox Studio is identified by source-layer name; when GIS data is re-uploaded, update `MTN_BIKE_SOURCE_LAYER` in `src/data/mountain-bike-trails.ts` and `MVT_TILESET` in `scripts/add_trail_elevation.py`. See `CLAUDE.md` for Chrome DevTools snippets to discover current names.
+
+## Tech stack
+
+- **Framework**: Next.js 16 (App Router) + React 19
+- **Map**: Mapbox GL JS 3
+- **Styling**: Tailwind CSS, shadcn/ui primitives, Radix UI
+- **Icons**: Font Awesome, lucide-react
+- **Storage**: IndexedDB (rides, in-progress checkpoints) and cookies (settings)
+- **PWA**: Service worker + Web App Manifest
+- **Tooling**: TypeScript, Vitest, Biome + ESLint, pnpm
+- **Trail data pipeline**: Python (Mapbox vector tiles + Terrain-RGB)
+
+## Getting started
 
 ### Prerequisites
 
 - Node.js 20+
 - pnpm 10+ (recommended) or npm
 
-### Installation
+### Install and run
 
-1. Clone the repository:
 ```bash
 git clone https://github.com/kwiens/bikemap.git
 cd bikemap
-```
-
-2. Install dependencies:
-```bash
 pnpm install
+cp .env.example .env.local         # add your Mapbox token if needed
+pnpm dev                           # http://localhost:3000
 ```
 
-3. Set up environment variables (MapBox secret key):
-```bash
-cp .env.example .env.local
-# Add your Mapbox token if using a custom one
-```
+### Scripts
 
-4. Run the development server:
-```bash
-pnpm dev
-```
+| Command | What it does |
+|---|---|
+| `pnpm dev` | Development server |
+| `pnpm build` | Production build |
+| `pnpm start` | Run production build |
+| `pnpm test` | Vitest in watch mode |
+| `pnpm test:run` | Vitest single run |
+| `pnpm lint` | ESLint + Biome lint + Biome format checks |
+| `pnpm lint:fix` | Auto-fix lint and formatting |
 
-5. Open [http://localhost:3000](http://localhost:3000) to view the map
+### Trail elevation pipeline (Python)
 
-### Development Scripts
-
-- `pnpm dev` - Start development server
-- `pnpm build` - Build for production
-- `pnpm start` - Start production server
-- `pnpm test` - Run tests in watch mode
-- `pnpm test:run` - Run tests once
-- `pnpm lint` - Check code quality
-- `pnpm lint:fix` - Auto-fix linting issues
-
-## Running Tests
-
-The project includes comprehensive test coverage for critical features:
+Required only if you are curating new trail data.
 
 ```bash
-# Run all tests
-pnpm test:run
+# Generate elevation for one trail
+python scripts/add_trail_elevation.py --trail "Stringer's Ridge"
 
-# Run tests in watch mode
-pnpm test
+# Generate for every trail in the manifest
+python scripts/add_trail_elevation.py
 ```
 
-Test coverage includes:
-- GBFS API integration (bike share data fetching)
-- Mapbox geocoding and geospatial utilities
-- Route calculations and mapping functions
+Outputs `public/data/elevation/{slug}.json` and updates summary stats in `src/data/mountain-bike-trails.ts`. See `CLAUDE.md` for guidance on adding a new trail end-to-end.
 
-## Project Structure
+## Testing
 
-```
-bikemap/
-├── src/
-│   ├── app/              # Next.js app directory
-│   ├── components/       # React components
-│   │   ├── ui/          # Reusable UI components
-│   │   ├── Map.tsx      # Main map component
-│   │   └── MapMarkers.tsx
-│   ├── data/            # Data sources and types
-│   │   ├── gbfs.ts      # Bike share API integration
-│   │   └── geo_data.ts  # Routes, attractions, resources
-│   ├── utils/           # Utility functions
-│   └── hooks/           # React hooks
-├── public/              # Static assets
-├── tests/               # Test setup and utilities
-└── .github/workflows/   # CI/CD workflows
-```
+Tests live next to source as `*.test.ts(x)` and run under Vitest with jsdom. Coverage spans:
+
+- GBFS API integration (fetching and shaping bike-share data)
+- Geocoding, route opacity, bounds utilities
+- Ride statistics (distance, moving time, elevation gain with smoothing)
+- Ride storage (IndexedDB via `fake-indexeddb`)
+- DEM elevation correction
+- GPX building and parsing
+- Compass heading smoothing
+- Sidebar components (BikeRoutes, MountainBikeTrails, ElevationProfile, RidesPanel, WelcomeModal)
+
+Mapbox layer events cannot be triggered synthetically — for layer-click testing, dispatch the corresponding custom event from `src/events.ts` directly.
+
+## Deploying for your community
+
+The fastest path:
+
+1. Fork the repo.
+2. Edit `src/config/map.config.ts` for your region.
+3. Replace data in `src/data/` (routes, trails, shops, POIs).
+4. Style your routes and trails in Mapbox Studio; update layer IDs in the data files.
+5. Run the trail elevation script if you have mountain bike trails.
+6. Deploy on any Node host. Vercel works out of the box.
 
 ## Contributing
 
-We welcome contributions from the community! Whether you're fixing bugs, adding features, or improving documentation, your help makes this project better for everyone.
+Pull requests welcome. For larger changes — new capabilities, a new community deployment, or pipeline changes — open an issue first so we can talk through the shape.
 
-### How to Contribute
-
-1. **Fork the repository**
-2. **Create a feature branch** (`git checkout -b feature/amazing-feature`)
-3. **Make your changes** and add tests if applicable
-4. **Run tests and linting** (`pnpm test:run && pnpm lint`)
-5. **Commit your changes** (`git commit -m 'Add amazing feature'`)
-6. **Push to your branch** (`git push origin feature/amazing-feature`)
-7. **Open a Pull Request**
-
-### Reporting Issues
-
-Found a bug or have a feature request? Please [open an issue](https://github.com/kwiens/bikemap/issues) with:
-- A clear description of the problem or suggestion
-- Steps to reproduce (for bugs)
-- Screenshots if applicable
-- Your environment (browser, OS, etc.)
-
-### Code of Conduct
-
-This project is dedicated to providing a welcoming and inclusive experience for everyone. Please be respectful and constructive in all interactions.
-
-## Tech Stack
-
-- **Framework**: [Next.js](https://nextjs.org/) (React)
-- **Styling**: [Tailwind CSS](https://tailwindcss.com/)
-- **Mapping**: [Mapbox GL JS](https://www.mapbox.com/mapbox-gljs)
-- **UI Components**: [Radix UI](https://www.radix-ui.com/)
-- **Icons**: [Font Awesome](https://fontawesome.com/)
-- **Testing**: [Vitest](https://vitest.dev/)
-- **Package Manager**: [pnpm](https://pnpm.io/)
-- **Linting**: ESLint + [Biome](https://biomejs.dev/)
+1. Fork and create a feature branch.
+2. Make your change with tests where it makes sense.
+3. `pnpm test:run && pnpm lint`.
+4. Open a PR.
 
 ## Dedication
 
@@ -144,14 +190,15 @@ This project is dedicated to the memory of our friend and collaborator Yoseph. I
 
 ## License
 
-This project is open source and available under the [MIT License](LICENSE).
+MIT — see [LICENSE](LICENSE).
 
 ## Acknowledgments
 
-- Thanks to the Chattanooga cycling community for route curation and feedback
-- [Bike Chattanooga](https://bikechatt.com) for providing bike share infrastructure
+- The Chattanooga cycling community for route curation, trail data, and feedback
+- [Bike Chattanooga](https://bikechatt.com) for bike-share infrastructure
+- [SORBA Chattanooga](https://www.sorbachatt.org/) and the trail builders behind the regional MTB network
 - [iFixit](https://www.ifixit.com) for supporting open-source community projects
 
 ---
 
-Made with ❤️ in Chattanooga, TN
+Made with ❤️ in Chattanooga, TN — and ready for your community next.


### PR DESCRIPTION
## Summary

- Reframes BikeMap as an open-source platform any community can fork, with Chattanooga as the reference deployment.
- Documents capabilities the prior README didn't mention: 225+ MTB trails with elevation profiles, GPS ride recording (pause/resume, wake lock, crash recovery, IndexedDB), DEM-based elevation correction, GPX import/export, PWA install, multi-geography config model, and the Python trail pipeline.
- Updates tech stack to Next.js 16 + React 19 and adds a fork-and-ship checklist for new communities.

## Test plan

- [ ] Render `README.md` on GitHub and confirm formatting (headings, table, image grid, code blocks).
- [ ] Spot-check that referenced files exist: `src/config/map.config.ts`, `src/data/mountain-bike-trails.ts`, `scripts/add_trail_elevation.py`, `src/events.ts`.
- [ ] Confirm screenshot links still resolve (`public/screenshot-splash.png`, `public/screenshot-route.png`).