### PR TITLE
Ignore tsconfig.tsbuildinfo and .codex build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ build
 .DS_Store
 *.pem
 
+# build artifacts
+tsconfig.tsbuildinfo
+
+# codex
+.codex
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary

Adds two generated artifacts to `.gitignore` so they stop appearing as untracked files:

- `tsconfig.tsbuildinfo` — TypeScript incremental build cache
- `.codex` — local Codex tooling directory

Neither was tracked before; this just stops `git status` noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)