### PR TITLE
Phase 2: fork DX & docs (re-target to main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ out/
 build
 *.tsbuildinfo
 
+# python (trail-data scripts)
+.venv/
+__pycache__/
+*.pyc
+
 # misc
 .DS_Store
 *.pem

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/kwiens/bikemap/actions/workflows/test.yml">
+    <img src="https://github.com/kwiens/bikemap/actions/workflows/test.yml/badge.svg" alt="Tests">
+  </a>
+</p>
+
 An open-source trail and bike-route platform for any community. Browse curated road and greenway routes, hundreds of mountain bike trails with elevation profiles, real-time bike share availability, and record your own rides with GPS — all in a fast, mobile-first web app you can install to your home screen.
 
 The included reference deployment is configured for [Chattanooga, TN](https://bikechatt.com), but the codebase is built so a new community can fork it, swap configuration and data, and ship.
@@ -17,51 +23,43 @@ The included reference deployment is configured for [Chattanooga, TN](https://bi
 
 ## Make it yours
 
-Open Bike Map is designed to be re-skinned for a new community in an afternoon, not a quarter. Every piece a community would want to control is intentionally pulled out of the code and into a small, well-marked set of files:
+Open Bike Map is a fork-and-edit, not a rewrite. Everything a community controls is pulled out of the code into a small set of well-marked files:
 
-- **One config file for your geography.** `src/config/map.config.ts` holds the Mapbox style, default map view, GBFS feed, and region metadata. Point it at your area and the map opens there.
-- **Plain TypeScript data, not a CMS.** Routes, mountain bike trails, attractions, bike shops, and local resources are typed arrays in `src/data/`. Add an entry, ship a PR — no database, no admin panel, no backend.
-- **Style your routes in Mapbox Studio.** Curate route lines visually, then reference the layer IDs from `bike-routes.ts`. Trails come from a vector tileset you control.
-- **Trail data is automated.** Drop your trail tileset in, run `scripts/add_trail_elevation.py`, and the script generates per-trail elevation profiles, distances, and bounding boxes from Mapbox Vector Tiles + Terrain-RGB. No manual GPX wrangling.
-- **Bring-your-own bike share (or skip it).** If your city publishes a [GBFS](https://gbfs.org/) feed, change one URL. If it doesn't, hide the layer.
-- **Brand it.** Replace logos in `public/`, swap the welcome copy in `WelcomeModal.tsx`, adjust the brand colors in `tailwind.config.ts` (`app-primary` / `app-secondary`).
+- **`src/config/site.config.ts`** — branding (name, description, colors, PWA identity).
+- **`src/config/map.config.ts`** — geography (Mapbox style, default view, GBFS feed, region).
+- **`src/data/*`** — routes, trails, shops, and points of interest as plain typed arrays. No database, no CMS.
+- **`public/*`** — logos, icons, splash screens.
 
-A community fork is a fork-and-edit, not a rewrite. The included build is just one set of inputs to a generic engine — see [Deploying for your community](#deploying-for-your-community) below for the step-by-step.
+The full step-by-step is in **[docs/DEPLOYING.md](docs/DEPLOYING.md)**; the data-file contract is in **[docs/DATA.md](docs/DATA.md)**.
 
 ## Features
 
 ### For riders
 
 - **Curated bike routes** — Hand-picked road, greenway, and connector routes styled in Mapbox Studio with descriptions, distance, and zoom-to-fit bounds.
-- **Mountain bike trails** — 225+ trails in the reference deployment, grouped by recreation area and region, color-coded by difficulty, with per-trail elevation profiles (gain/loss/min/max and a sampled distance-vs-elevation chart).
+- **Mountain bike trails** — 225+ trails in the reference deployment, grouped by recreation area and region, color-coded by difficulty, with per-trail elevation profiles.
 - **Real-time bike share** — Live station availability via the [GBFS](https://gbfs.org/) standard, configurable per region.
 - **Points of interest** — Attractions, bike shops, rentals, and local resources as toggleable map layers.
 - **Live location & compass** — Tracks position and heading, with a smoothed compass heading derived from GPS readings.
-- **Welcome onboarding** — Asks new users whether they ride Casual (greenways/loops) or Mountain (singletrack) and tailors the default view.
-- **Installable PWA** — Manifest, service worker, custom splash screens, and an in-app install prompt for iOS and Android home-screen install.
-- **Mobile-first UI** — Collapsible sidebar, touch-friendly controls, and resize handling that reflows the map when the sidebar opens or closes.
+- **Installable PWA** — Manifest, service worker, custom splash screens, and an in-app install prompt for iOS and Android.
+- **Mobile-first UI** — Collapsible sidebar, touch-friendly controls, and resize handling that reflows the map.
 
 ### Ride recording
 
-A full GPS ride tracker, all client-side:
+A full client-side GPS ride tracker:
 
-- Start, pause, resume, and stop with live distance, elapsed time, and elevation gain.
-- Wake-lock support keeps the screen on during a ride.
-- Accuracy gating (`MAX_ACCURACY_M`) discards bad GPS fixes before they pollute stats.
-- Elevation smoothing via EMA + dead-band + spike filtering, then optional DEM correction against Mapbox Terrain-RGB tiles for clean elevation profiles.
-- **Crash recovery** — Rides are checkpointed to IndexedDB so a browser crash, accidental tab close, or backgrounded mobile app can be recovered on next load.
-- **Background-gap detection** — If GPS goes silent for too long (mobile backgrounding), recording pauses gracefully.
-- Rides are saved locally to IndexedDB. Browse history, view per-ride detail with the route drawn on the map and elevation chart, and export as **GPX**.
+- Start, pause, resume, stop with live distance, elapsed time, and elevation gain.
+- Wake-lock keeps the screen on; accuracy gating discards bad GPS fixes.
+- Elevation smoothing (EMA + dead-band + spike filtering) with optional DEM correction against Mapbox Terrain-RGB.
+- **Crash recovery** — rides are checkpointed to IndexedDB and recoverable after a crash or tab close.
+- **Background-gap detection** — recording pauses gracefully when GPS goes silent.
+- Rides save locally to IndexedDB; browse history, view per-ride detail, and export as **GPX**.
 
 ### For curators / community maintainers
 
-- **Configurable map** — `src/config/map.config.ts` centralizes the Mapbox token, style URL, default view (center/zoom/pitch/bearing), GBFS endpoints, and region metadata. Forking for a new community starts here.
-- **Trail tooling (Python)** — Scripts to extract trail geometry from a Mapbox vector tileset and sample elevation from Terrain-RGB, producing per-trail JSON profiles and updating the trail manifest with distance, gain/loss, and bounds:
-  - `scripts/add_trail_bounds.py` — Recompute bounding boxes and lengths from raw layer coordinates.
-  - `scripts/add_trail_elevation.py` — Generate `public/data/elevation/{slug}.json` and update `src/data/mountain-bike-trails.ts`.
-  - `scripts/validate_trails.py` — Sanity-check the trail manifest.
-- **Bidirectional events** — Components communicate via custom DOM events (`route-select`, `layer-toggle`, `center-location`, `route-deselect`, `sidebar-toggle`), so clicking a route on the map syncs the sidebar and vice versa. See `src/events.ts`.
-- **GPX import/export** — Round-trip rides and routes via the standard GPX 1.1 format.
+- **Two config files** drive geography and branding; content is plain TypeScript in `src/data/` — see [docs/DATA.md](docs/DATA.md).
+- **Trail tooling** — Python scripts extract trail geometry from a Mapbox tileset and sample elevation from Terrain-RGB to generate per-trail profiles. See [docs/DEPLOYING.md](docs/DEPLOYING.md).
+- **GPX import/export** — round-trip rides and routes via the standard GPX 1.1 format.
 
 ## Architecture
 
@@ -69,50 +67,29 @@ Built on Next.js App Router with Mapbox GL JS for rendering. The map canvas is d
 
 ```
 src/
-├── app/                   Next.js App Router pages (map, about, export, test)
+├── app/                   Next.js App Router pages
 ├── components/
 │   ├── Map.tsx            Main map orchestrator (init, markers, custom events)
 │   ├── MapLegend.tsx      Sidebar container & state
 │   ├── MapMarkers.tsx     Marker factories and MarkerManager
 │   ├── RidesPanel.tsx     Ride recording controls and history
 │   ├── WelcomeModal.tsx   First-run onboarding & ride-style preference
-│   ├── PwaInstallPrompt   Install-to-home-screen prompt
 │   └── sidebar/           BikeRoutes, MountainBikeTrails, MapLayers,
-│                          AttractionsList, BikeRentalList, BikeResourcesList,
 │                          ElevationProfile, RideHistory, RideDetail, ...
-├── config/map.config.ts   Geo-specific configuration (Mapbox, GBFS, region)
-├── data/
-│   ├── bike-routes.ts             Curated road/greenway routes
-│   ├── mountain-bike-trails.ts    Trail manifest (225+ in the reference build)
-│   ├── bike-resources.ts          Shops & repair stations
-│   ├── local-resources.ts         Community resources
-│   ├── map-features.ts            Attractions / POIs
-│   ├── gbfs.ts                    Live bike share API integration
-│   └── ride.ts                    Recorded-ride types & helpers
-├── hooks/                 useRideRecording, useLocationTracking, useWakeLock,
-│                          useMapResize, useToast, use-mobile
+├── config/
+│   ├── site.config.ts     Branding / app identity
+│   └── map.config.ts      Geo-specific configuration (Mapbox, GBFS, region)
+├── data/                  Routes, trails, shops, POIs — see docs/DATA.md
+├── hooks/                 useRideRecording, useWakeLock, useMapResize,
+│                          useToast, use-mobile
 ├── utils/                 ride-stats, ride-storage (IndexedDB), dem (Terrain-RGB
-│                          elevation correction), gpx, gpx-parser, compass,
-│                          format, settings, map (geocoding & bounds), svg
+│                          elevation correction), gpx, compass, map, format
 ├── events.ts              Custom DOM event constants
 └── lib/utils.ts           cn() — clsx + tailwind-merge
 
 public/data/elevation/     Per-trail elevation JSON
-public/terrain/            Local terrain assets
 scripts/                   Python tooling for trails & elevation
 ```
-
-### Configuration model
-
-Everything geography-specific lives in `src/config/map.config.ts`. The included config is the reference; a new community ships by:
-
-1. Replacing the Mapbox style URL and access token (or sourcing them from env).
-2. Updating `defaultView` (center/zoom/pitch/bearing) for the area you want to land on.
-3. Pointing `gbfs.baseUrl` at your local GBFS feed (or removing the bike-share layer if there is none).
-4. Replacing the data files in `src/data/` with your routes, trails, shops, and POIs.
-5. Re-running `scripts/add_trail_elevation.py` to generate elevation profiles for your trails.
-
-The trail layer in Mapbox Studio is identified by source-layer name; when GIS data is re-uploaded, update `MTN_BIKE_SOURCE_LAYER` in `src/data/mountain-bike-trails.ts` and `MVT_TILESET` in `scripts/add_trail_elevation.py`. See `CLAUDE.md` for Chrome DevTools snippets to discover current names.
 
 ## Tech stack
 
@@ -120,27 +97,24 @@ The trail layer in Mapbox Studio is identified by source-layer name; when GIS da
 - **Map**: Mapbox GL JS 3
 - **Styling**: Tailwind CSS, shadcn/ui primitives, Radix UI
 - **Icons**: Font Awesome, lucide-react
-- **Storage**: IndexedDB (rides, in-progress checkpoints) and cookies (settings)
+- **Storage**: IndexedDB (rides) and cookies (settings)
 - **PWA**: Service worker + Web App Manifest
 - **Tooling**: TypeScript, Vitest, Biome + ESLint, pnpm
 - **Trail data pipeline**: Python (Mapbox vector tiles + Terrain-RGB)
 
 ## Getting started
 
-### Prerequisites
-
-- Node.js 20+
-- pnpm 10+ (recommended) or npm
-
-### Install and run
+**Prerequisites:** Node.js 20+ and pnpm 10+.
 
 ```bash
 git clone https://github.com/kwiens/bikemap.git
 cd bikemap
 pnpm install
-cp .env.example .env.local         # add your Mapbox token if needed
+cp .env.example .env.local         # add your Mapbox token — see .env.example
 pnpm dev                           # http://localhost:3000
 ```
+
+A free [Mapbox](https://account.mapbox.com/access-tokens/) public token is required for the map to render.
 
 ### Scripts
 
@@ -149,89 +123,39 @@ pnpm dev                           # http://localhost:3000
 | `pnpm dev` | Development server |
 | `pnpm build` | Production build |
 | `pnpm start` | Run production build |
-| `pnpm test` | Vitest in watch mode |
-| `pnpm test:run` | Vitest single run |
-| `pnpm lint` | ESLint + Biome lint + Biome format checks |
-| `pnpm lint:fix` | Auto-fix lint and formatting |
+| `pnpm test` / `pnpm test:run` | Vitest (watch / single run) |
+| `pnpm lint` / `pnpm lint:fix` | Lint + format (check / auto-fix) |
 
-### Trail elevation pipeline (Python)
-
-Required only if you are curating new trail data.
-
-```bash
-# Generate elevation for one trail
-python scripts/add_trail_elevation.py --trail "Stringer's Ridge"
-
-# Generate for every trail in the manifest
-python scripts/add_trail_elevation.py
-```
-
-Outputs `public/data/elevation/{slug}.json` and updates summary stats in `src/data/mountain-bike-trails.ts`. See `CLAUDE.md` for guidance on adding a new trail end-to-end.
+The Python trail-elevation pipeline is optional and documented in [docs/DEPLOYING.md](docs/DEPLOYING.md).
 
 ## Testing
 
-Tests live next to source as `*.test.ts(x)` and run under Vitest with jsdom. Coverage spans:
-
-- GBFS API integration (fetching and shaping bike-share data)
-- Geocoding, route opacity, bounds utilities
-- Ride statistics (distance, moving time, elevation gain with smoothing)
-- Ride storage (IndexedDB via `fake-indexeddb`)
-- DEM elevation correction
-- GPX building and parsing
-- Compass heading smoothing
-- Sidebar components (BikeRoutes, MountainBikeTrails, ElevationProfile, RidesPanel, WelcomeModal)
+Tests live next to source as `*.test.ts(x)` and run under Vitest with jsdom — covering GBFS integration, ride stats and storage, DEM correction, GPX build/parse, compass smoothing, and sidebar components.
 
 Mapbox layer events cannot be triggered synthetically — for layer-click testing, dispatch the corresponding custom event from `src/events.ts` directly.
 
 ## Deploying for your community
 
-The fastest path:
+Fork the repo and follow **[docs/DEPLOYING.md](docs/DEPLOYING.md)** — it walks through Mapbox setup, the two config files, the `src/data/` content ([docs/DATA.md](docs/DATA.md)), brand assets, and deploying to Vercel or any Node host.
 
-1. Fork the repo.
-2. Edit `src/config/map.config.ts` for your region.
-3. Replace data in `src/data/` (routes, trails, shops, POIs).
-4. Style your routes and trails in Mapbox Studio; update layer IDs in the data files.
-5. Run the trail elevation script if you have mountain bike trails.
-6. Deploy on any Node host. Vercel works out of the box.
+## Contributing
+
+Pull requests welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup and conventions, and the [Code of Conduct](CODE_OF_CONDUCT.md). For larger changes (new capabilities, a new community deployment, pipeline changes), open an issue first.
 
 ## Future work
 
 ### Native app wrapper for the App Store and Google Play
 
-Open Bike Map is already a Progressive Web App — it installs to the home screen, runs offline-friendly via a service worker, requests GPS / wake-lock / motion permissions, and ships custom splash screens. PWA install covers the technical case well, but it doesn't match how most riders look for a bike app: they search the App Store or Google Play.
+Open Bike Map is already a Progressive Web App — it installs to the home screen, runs offline-friendly via a service worker, and ships custom splash screens. But that doesn't match how most riders look for a bike app: they search the App Store or Google Play.
 
-The plan is to ship a thin native wrapper around the existing web app — most likely [Capacitor](https://capacitorjs.com/) — so the same codebase ships to:
-
-- **iOS App Store** (Capacitor → native iOS shell)
-- **Google Play** (Capacitor → native Android shell)
-- **Web** (the current PWA, unchanged)
-
-What the wrapper buys us beyond the PWA:
-
-- **Discoverability** in the platform stores so a community deployment shows up for "[your city] bike map" searches.
-- **Better background GPS** for long rides, where mobile browsers throttle or suspend `geolocation` watchers.
-- **More reliable wake lock** and screen-on behavior across devices.
-- **Native share sheets** for exporting GPX rides into Strava, Komoot, etc.
-- **Push notifications** down the road — trail-condition alerts, new-route announcements per community.
-- **Apple Maps / Google Maps deep links** for "navigate to this trailhead."
-
-The architectural bet here is that the web app stays the source of truth and the wrapper is mechanical. Each community deployment can then choose: PWA-only (free, instant) or store-listed (one-time native build pipeline per community brand).
+The plan is a thin native wrapper around the existing web app — most likely [Capacitor](https://capacitorjs.com/) — shipping the same codebase to the iOS App Store and Google Play alongside the web PWA. Beyond discoverability, it buys better background GPS for long rides, more reliable wake lock, native share sheets for GPX export, and a path to push notifications. The web app stays the source of truth; the wrapper is mechanical.
 
 ### Other things on the roadmap
 
 - **Multi-community switcher** — host several cities from one deployment by selecting `mapConfig` per route or subdomain.
 - **Trail conditions / closures** — community-curated overlay so locals can flag a trail as wet, closed, or rerouted.
-- **Cloud ride sync (opt-in)** — rides are local-only today; an optional account would let riders see history across devices.
+- **Cloud ride sync (opt-in)** — rides are local-only today; an optional account would sync history across devices.
 - **Heatmaps from recorded rides** — anonymized aggregate to surface which informal connectors riders actually use.
-
-## Contributing
-
-Pull requests welcome. For larger changes — new capabilities, a new community deployment, or pipeline changes — open an issue first so we can talk through the shape.
-
-1. Fork and create a feature branch.
-2. Make your change with tests where it makes sense.
-3. `pnpm test:run && pnpm lint`.
-4. Open a PR.
 
 ## Dedication
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ src/
 ├── hooks/                 useRideRecording, useWakeLock, useMapResize,
 │                          useToast, use-mobile
 ├── utils/                 ride-stats, ride-storage (IndexedDB), dem (Terrain-RGB
-│                          elevation correction), gpx, compass, map, format
+│                          elevation correction), gpx, compass, map, format, ...
 ├── events.ts              Custom DOM event constants
 └── lib/utils.ts           cn() — clsx + tailwind-merge
 
 public/data/elevation/     Per-trail elevation JSON
+public/terrain/            Pre-cached DEM tiles (region-specific; see docs/DEPLOYING.md)
 scripts/                   Python tooling for trails & elevation
 ```
 

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,0 +1,98 @@
+# Data files
+
+All content shown on the map lives in `src/data/` as plain, typed TypeScript
+arrays — no database, no CMS, no admin panel. To change what a deployment
+shows, edit an array and ship a PR.
+
+Each file exports a typed array; the `interface` at the top of the file is the
+contract. `icon` fields are Font Awesome `IconDefinition` values imported from
+`@fortawesome/free-solid-svg-icons` — use an existing icon, don't add a new
+library.
+
+| File | Export | What it is |
+|---|---|---|
+| `bike-routes.ts` | `bikeRoutes: BikeRoute[]` | Curated road / greenway routes |
+| `mountain-bike-trails.ts` | `mountainBikeTrails: MountainBikeTrail[]` | MTB trail manifest |
+| `bike-resources.ts` | `bikeResources: BikeResource[]` | Bike shops & repair stations |
+| `map-features.ts` | `mapFeatures: MapFeature[]` | Attractions / points of interest |
+| `local-resources.ts` | `localResources: LocalResource[]` | Community resource links |
+| `gbfs.ts` | — | Live bike-share API client (no static data) |
+
+`geo_data.ts` is a barrel that re-exports the above; import from `@/data/geo_data`.
+
+## BikeRoute (`bike-routes.ts`)
+
+Routes are line layers styled in Mapbox Studio; the entry here wires a layer to
+its sidebar card.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `string` | **Must equal the Mapbox Studio layer ID** for this route |
+| `name` | `string` | Display name |
+| `color` | `string` | Hex; should match the layer's color in Studio |
+| `description` | `string` | Sidebar copy |
+| `icon` | `IconDefinition` | Font Awesome icon |
+| `defaultWidth` | `number` | Line width in px |
+| `opacity` | `number` | 0–1 |
+| `distance` | `number` | Miles |
+| `defaultBounds?` | `[swLng, swLat, neLng, neLat]` | Zoom-to-fit fallback when runtime bounds aren't available |
+| `bounds?` | `mapboxgl.LngLatBounds` | Computed at runtime — do not hand-author |
+
+## MountainBikeTrail (`mountain-bike-trails.ts`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `trailName` | `string` | **Must equal the `Trail` feature property** in the trail tileset |
+| `displayName` | `string` | Human-friendly name |
+| `recArea` | `string` | Recreation-area grouping; map it to a region in `REGION_MAP` |
+| `rating` | `string` | `easy` \| `intermediate` \| `advanced` \| `expert` \| `''` — drives the color |
+| `color` | `string` | Use the `trailColor()` helper in this file |
+| `icon` | `IconDefinition` | Font Awesome icon |
+| `distance?` | `number` | Miles — **script-generated** |
+| `elevationGain/Loss/Min/Max?` | `number` | Feet — **script-generated** |
+| `defaultBounds?` | `[swLng, swLat, neLng, neLat]` | **script-generated** |
+| `bounds?` | `mapboxgl.LngLatBounds` | Runtime only |
+
+`REGION_MAP` (same file) maps each `recArea` to a geographic region for the
+sidebar grouping — add an entry when you introduce a new `recArea`.
+
+## BikeResource (`bike-resources.ts`) & MapFeature (`map-features.ts`)
+
+Point markers. `BikeResource` is `name`, `description`, `address`, `latitude`,
+`longitude`. `MapFeature` is the same plus an `icon`.
+
+## LocalResource (`local-resources.ts`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `name`, `description`, `url` | `string` | Resource card; `url` may be a path (`/about`) or external |
+| `icon` | `IconDefinition` | Font Awesome icon |
+| `colorTheme` | `'blue' \| 'green' \| 'purple' \| 'gray'` | Card accent |
+| `secondaryDescription?` / `secondaryUrl?` / `secondaryLinkText?` | `string` | Optional second link |
+
+## Script-generated fields
+
+The Python scripts in `scripts/` own these fields — hand-authoring them is
+pointless, they get overwritten. See [DEPLOYING.md](DEPLOYING.md) for setup.
+
+| Script | Writes |
+|---|---|
+| `add_trail_elevation.py` | `MountainBikeTrail` elevation stats (`elevationGain/Loss/Min/Max`, `distance`) + per-trail `public/data/elevation/{slug}.json` |
+| `add_trail_bounds.py` | `MountainBikeTrail.defaultBounds` and `distance` |
+| `validate_trails.py` | Read-only — flags geometry/elevation anomalies |
+
+### Per-trail elevation JSON (`public/data/elevation/{slug}.json`)
+
+Written by `add_trail_elevation.py`, consumed by the elevation chart:
+
+```ts
+interface ElevationProfile {
+  trail: string;
+  distance: number;        // total distance, feet
+  gain: number;            // feet
+  loss: number;            // feet
+  min: number;             // feet
+  max: number;             // feet
+  profile: [number, number, number, number][]; // [distance_ft, elevation_ft, lng, lat]
+}
+```

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -46,7 +46,7 @@ its sidebar card.
 | `displayName` | `string` | Human-friendly name |
 | `recArea` | `string` | Recreation-area grouping; map it to a region in `REGION_MAP` |
 | `rating` | `string` | `easy` \| `intermediate` \| `advanced` \| `expert` \| `''` — drives the color |
-| `color` | `string` | Use the `trailColor()` helper in this file |
+| `color` | `string` | Use the `trailColor(rating, isGreenway)` helper in this file |
 | `icon` | `IconDefinition` | Font Awesome icon |
 | `distance?` | `number` | Miles — **script-generated** |
 | `elevationGain/Loss/Min/Max?` | `number` | Feet — **script-generated** |

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -97,7 +97,23 @@ python scripts/validate_trails.py              # sanity-check
 
 This populates the script-generated fields documented in [DATA.md](DATA.md).
 
-## 8. Brand assets — `public/`
+## 8. Ride-recording elevation tiles — `public/terrain/` (optional)
+
+The ride recorder corrects noisy GPS altitude against pre-cached Mapbox
+Terrain-RGB tiles served locally from `public/terrain/{z}/{x}/{y}.png` (see
+`src/utils/dem.ts`). **The committed tiles cover the Chattanooga area only**
+(z13, ~21 MB).
+
+This degrades gracefully: for points outside the cached tiles, recorded rides
+keep their raw GPS altitude — nothing breaks, but ride elevation profiles are
+less accurate. For your region, either:
+
+- **Skip it** — delete `public/terrain/` and ship without DEM correction, or
+- **Regenerate it** — cache z13 Terrain-RGB tiles covering your area under
+  `public/terrain/13/{x}/{y}.png` (256px `mapbox.terrain-rgb` tiles). There is
+  no script for this yet; it's a manual tile fetch.
+
+## 9. Brand assets — `public/`
 
 Replace with your own:
 
@@ -107,7 +123,7 @@ Replace with your own:
 - **iOS splash screens** — `public/splash/*`
 - **README screenshots** — `screenshot-splash.png`, `screenshot-route.png`
 
-## 9. Deploy
+## 10. Deploy
 
 ```bash
 pnpm build      # verify the production build locally
@@ -125,5 +141,6 @@ Any Node host works — `pnpm build` then `pnpm start`.
 - [ ] `src/data/*` — routes, trails, shops, POIs ([DATA.md](DATA.md))
 - [ ] Route layer IDs and trail tileset wired to Mapbox Studio
 - [ ] Trail elevation script run (if you have MTB trails)
+- [ ] `public/terrain/` DEM tiles regenerated or removed (ride-recording elevation)
 - [ ] `public/` brand assets replaced
 - [ ] `pnpm build` passes; host env var set

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -79,6 +79,9 @@ contract of `BikeRoute`, `MountainBikeTrail`, `BikeResource`, `MapFeature`, and
   Each `MountainBikeTrail.trailName` must match the tileset's `Trail` feature
   property. See `CLAUDE.md` for DevTools snippets to discover layer/tileset
   names after a GIS re-upload.
+  - **Keep the elevation script in sync:** `scripts/add_trail_elevation.py`
+    has its own `MVT_TILESET` constant. If you use the pipeline in step 7,
+    point it at the **same** tileset as `MTN_BIKE_TILESET_URL`.
 
 ## 7. Trail elevation pipeline (optional)
 

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -1,0 +1,126 @@
+# Deploying for your community
+
+Open Bike Map is designed to be re-skinned for a new community by forking the
+repo and editing a small, well-marked set of files — no rewrite. This is the
+end-to-end checklist. A condensed version is at the [bottom](#checklist).
+
+## Prerequisites
+
+- **Node.js 20+** and **pnpm 10+**
+- A free **[Mapbox](https://account.mapbox.com/)** account (map rendering,
+  vector tilesets, terrain)
+- **Python 3.10+** — only if you have mountain bike trails to process
+- A host for the build — **Vercel** works with zero config
+
+## 1. Fork and run locally
+
+```bash
+git clone https://github.com/<you>/bikemap.git
+cd bikemap
+pnpm install
+cp .env.example .env.local
+pnpm dev                       # http://localhost:3000
+```
+
+The map will be blank until you add a Mapbox token (next step) — the browser
+console says so explicitly.
+
+## 2. Mapbox setup
+
+1. In [Mapbox Studio](https://studio.mapbox.com/), create (or duplicate) a map
+   **style**. Note its style URL (`mapbox://styles/<user>/<id>`).
+2. Create a **public access token** at
+   <https://account.mapbox.com/access-tokens/> (starts with `pk.`). Scope it to
+   your domains.
+3. Put the token in `.env.local`:
+   ```
+   NEXT_PUBLIC_MAPBOX_TOKEN=pk.your_token_here
+   ```
+   Set the same variable in your host's environment for production.
+
+## 3. Branding — `src/config/site.config.ts`
+
+One file controls app identity. Edit every field:
+
+| Field | Used for |
+|---|---|
+| `name` / `shortName` | Page title, welcome modal, PWA manifest, iOS title |
+| `description` / `tagline` | Meta description, PWA manifest, welcome modal |
+| `url` | Canonical link |
+| `themeColor` / `backgroundColor` | PWA theme + splash (match your brand) |
+| `storageKeyPrefix` | Cookie / localStorage key prefix — **pick your own** so it's distinct per deployment |
+
+Brand colors also live in `tailwind.config.ts` as `app-primary` / `app-secondary`.
+
+## 4. Geography — `src/config/map.config.ts`
+
+| Field | What to set |
+|---|---|
+| `mapbox.styleUrl` | Your Mapbox style URL from step 2 |
+| `defaultView` | `center` `[lng, lat]`, `zoom`, `pitch`, `bearing` — where the map opens |
+| `gbfs.baseUrl` | Your city's [GBFS](https://gbfs.org/) feed, or remove the bike-share layer if there's none |
+| `region.name` / `region.displayName` | Your region's slug and display name |
+
+## 5. Content data — `src/data/`
+
+Replace the routes, trails, shops, and points of interest with your own. Each
+file is a typed array — see **[DATA.md](DATA.md)** for the full field-by-field
+contract of `BikeRoute`, `MountainBikeTrail`, `BikeResource`, `MapFeature`, and
+`LocalResource`.
+
+## 6. Routes & trails in Mapbox Studio
+
+- **Routes** — draw/upload each route as a line layer in your style, then set
+  each `BikeRoute.id` in `bike-routes.ts` to that layer's ID.
+- **Trails** — upload your mountain bike trail GIS data as a Mapbox **tileset**,
+  then set `MTN_BIKE_TILESET_URL` and `MTN_BIKE_SOURCE_LAYER` in
+  `src/data/mountain-bike-trails.ts`. The app attaches this tileset at runtime
+  (`ensureMtnBikeSource`), so it does not need to be in the Studio style.
+  Each `MountainBikeTrail.trailName` must match the tileset's `Trail` feature
+  property. See `CLAUDE.md` for DevTools snippets to discover layer/tileset
+  names after a GIS re-upload.
+
+## 7. Trail elevation pipeline (optional)
+
+Only if you have mountain bike trails. Generates per-trail elevation profiles
+and bounds from your tileset + Mapbox Terrain-RGB.
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r scripts/requirements.txt
+python scripts/add_trail_elevation.py          # all trails
+python scripts/validate_trails.py              # sanity-check
+```
+
+This populates the script-generated fields documented in [DATA.md](DATA.md).
+
+## 8. Brand assets — `public/`
+
+Replace with your own:
+
+- **Logos** — `public/Bike-Chatt_Logo-*.svg` (referenced by the About page;
+  rename and update the paths in `src/app/about/page.tsx`)
+- **Icons** — `favicon.png`, `icon-192.png`, `icon-512.png`, `apple-touch-icon.png`
+- **iOS splash screens** — `public/splash/*`
+- **README screenshots** — `screenshot-splash.png`, `screenshot-route.png`
+
+## 9. Deploy
+
+```bash
+pnpm build      # verify the production build locally
+```
+
+On **Vercel**: import the repo, and add `NEXT_PUBLIC_MAPBOX_TOKEN` under
+Settings → Environment Variables for **Production, Preview, and Development**.
+Any Node host works — `pnpm build` then `pnpm start`.
+
+## Checklist
+
+- [ ] `.env.local` has `NEXT_PUBLIC_MAPBOX_TOKEN`
+- [ ] `src/config/site.config.ts` — name, description, URL, colors, storage prefix
+- [ ] `src/config/map.config.ts` — style URL, default view, GBFS, region
+- [ ] `src/data/*` — routes, trails, shops, POIs ([DATA.md](DATA.md))
+- [ ] Route layer IDs and trail tileset wired to Mapbox Studio
+- [ ] Trail elevation script run (if you have MTB trails)
+- [ ] `public/` brand assets replaced
+- [ ] `pnpm build` passes; host env var set

--- a/scripts/add_trail_elevation.py
+++ b/scripts/add_trail_elevation.py
@@ -9,7 +9,7 @@ Output:
   - src/data/geo_data.ts               — summary stats (gain, loss, min, max)
 
 Usage: python scripts/add_trail_elevation.py
-Requires: pip install Pillow requests
+Requires: pip install -r scripts/requirements.txt
 """
 
 import gzip, json, math, os, re, struct, sys, time
@@ -28,15 +28,34 @@ _session.mount('https://', HTTPAdapter(
 # --- Constants ---
 
 def _read_mapbox_token():
-    """Read the Mapbox access token from map.config.ts."""
-    config_path = os.path.join(os.path.dirname(__file__), '..', 'src', 'config', 'map.config.ts')
-    with open(config_path) as f:
-        content = f.read()
-    match = re.search(r"accessToken:\s*['\"](.+?)['\"]", content)
-    if not match:
-        print("Error: Could not find accessToken in src/config/map.config.ts")
-        sys.exit(1)
-    return match.group(1)
+    """Resolve the Mapbox token the same way the app does.
+
+    The token is no longer a literal in map.config.ts — it comes from
+    NEXT_PUBLIC_MAPBOX_TOKEN (see .env.example). Prefer the environment, then
+    fall back to parsing .env.local / .env at the repo root.
+    """
+    token = os.environ.get('NEXT_PUBLIC_MAPBOX_TOKEN')
+    if token and token.strip():
+        return token.strip()
+
+    root = os.path.join(os.path.dirname(__file__), '..')
+    for env_file in ('.env.local', '.env'):
+        path = os.path.join(root, env_file)
+        if not os.path.exists(path):
+            continue
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('NEXT_PUBLIC_MAPBOX_TOKEN='):
+                    value = line.split('=', 1)[1].strip().strip('"').strip("'")
+                    if value:
+                        return value
+
+    print(
+        "Error: Mapbox token not found. Set NEXT_PUBLIC_MAPBOX_TOKEN in your "
+        "environment or add it to .env.local (see .env.example)."
+    )
+    sys.exit(1)
 
 MAPBOX_TOKEN = _read_mapbox_token()
 MVT_TILESET = 'swuller.ccfw1cmr'

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,11 @@
+# Python dependencies for the trail-data scripts (scripts/*.py).
+# Install into a virtualenv:
+#   python -m venv .venv && source .venv/bin/activate
+#   pip install -r scripts/requirements.txt
+#
+# Only needed if you are curating mountain bike trail data — the Next.js app
+# itself has no Python dependency.
+
+requests>=2.31      # Mapbox vector-tile + Terrain-RGB HTTP fetches
+urllib3>=2.0        # Retry adapter used directly by add_trail_elevation.py
+Pillow>=10.0        # decodes Terrain-RGB PNG tiles for elevation sampling


### PR DESCRIPTION
Re-lands #84 against `main`. #84 was merged with base `oss-phase1-hygiene` instead of `main`, so its content (`docs/DEPLOYING.md`, `docs/DATA.md`, `scripts/requirements.txt`, README trims, the env-token fix for the trail script, and the `public/terrain` deploy docs) never reached `main`. This PR brings that content to `main` so Phase 3 (#85) can rebase cleanly on top.

No new changes beyond what was reviewed in #84 plus the post-review terrain/token follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)