### PR TITLE
fix: elevation spike filter erased sustained climbs

### DIFF
--- a/scripts/osm_trail_elevation.py
+++ b/scripts/osm_trail_elevation.py
@@ -59,6 +59,7 @@ EARTH_RADIUS_M = 6371000.0
 # Ported verbatim from src/utils/ride-stats.ts. Keep in sync.
 ELEVATION_DEAD_BAND = 3
 ELEVATION_SPIKE_THRESHOLD = 25
+ELEVATION_SPIKE_MAX_RUN = 5
 ELEVATION_MIN_DISTANCE = 15
 ELEVATION_SMOOTH_HALF = 5  # 11-point centered window
 SPIKE_EMA_ALPHA = 0.3
@@ -291,12 +292,16 @@ def smooth_altitudes(points):
     seed_slice = sorted(raw_vals[:seed_count])
     spike_ema = seed_slice[len(seed_slice) // 2]
     vals = []
+    reject_run = 0
     for v in raw_vals:
-        if abs(v - spike_ema) > ELEVATION_SPIKE_THRESHOLD:
+        deviates = abs(v - spike_ema) > ELEVATION_SPIKE_THRESHOLD
+        if deviates and reject_run < ELEVATION_SPIKE_MAX_RUN:
             vals.append(spike_ema)
+            reject_run += 1
         else:
             vals.append(v)
-        spike_ema = SPIKE_EMA_ALPHA * vals[-1] + (1 - SPIKE_EMA_ALPHA) * spike_ema
+            reject_run = 0
+            spike_ema = SPIKE_EMA_ALPHA * v + (1 - SPIKE_EMA_ALPHA) * spike_ema
 
     for i in range(len(vals)):
         lo = max(0, i - ELEVATION_SMOOTH_HALF)

--- a/scripts/test_osm_trail_elevation.py
+++ b/scripts/test_osm_trail_elevation.py
@@ -1,0 +1,38 @@
+import unittest
+
+from osm_trail_elevation import compute_elevation
+
+
+def make_track(count, start_altitude, altitude_step):
+    return [
+        {
+            "lng": -85.3 + i * 0.0003,
+            "lat": 35.05 + i * 0.0003,
+            "altitude": start_altitude + i * altitude_step,
+        }
+        for i in range(count)
+    ]
+
+
+class ComputeElevationTest(unittest.TestCase):
+    def test_tracks_sustained_climb_when_spike_ema_lags(self):
+        points = make_track(200, start_altitude=1000, altitude_step=10)
+
+        gain, _loss, min_elevation, max_elevation = compute_elevation(points)
+
+        self.assertGreater(gain, 1700)
+        self.assertGreater(max_elevation - min_elevation, 1700)
+
+    def test_still_replaces_isolated_spike(self):
+        clean = make_track(200, start_altitude=1000, altitude_step=2)
+        spiked = [dict(point) for point in clean]
+        spiked[100]["altitude"] += 200
+
+        _gain, _loss, _min_elevation, clean_max = compute_elevation(clean)
+        _gain, _loss, _min_elevation, spiked_max = compute_elevation(spiked)
+
+        self.assertLess(abs(spiked_max - clean_max), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/ride-stats.test.ts
+++ b/src/utils/ride-stats.test.ts
@@ -165,6 +165,57 @@ describe('computeElevation', () => {
   // and points must be spaced > ELEVATION_MIN_DISTANCE apart (~15m).
   // At 0.0003° spacing (~33m/point), this simulates realistic rides.
 
+  // A sustained climb must survive the spike filter.
+  //
+  // The filter replaces a reading that is more than ELEVATION_SPIKE_THRESHOLD
+  // from a running EMA. It used to advance that EMA from the *substituted*
+  // value, which on a rejection is the EMA itself — so the update reduced to
+  // `ema = 0.3*ema + 0.7*ema` and the EMA froze permanently. Every later
+  // reading was then too far from a value that could no longer move, and was
+  // also replaced.
+  //
+  // On a real trail that erased a mountain: one rejection 7% into O'Leary
+  // Mountain flatlined the remaining 92% at 2,239 ft, reporting 449 ft of
+  // climbing on a trail that gains about 3,200.
+  it('keeps tracking a sustained climb the EMA cannot keep up with', () => {
+    // The spike filter compares each reading against a running EMA and
+    // replaces anything further away than ELEVATION_SPIKE_THRESHOLD. On a
+    // sustained climb the EMA *lags* — by roughly step * (1-alpha)/alpha —
+    // and on a steep enough slope that lag alone exceeds the threshold, with
+    // no spike anywhere in the data.
+    //
+    // The filter then held its reference while rejecting, so it could never
+    // catch up: the ground kept climbing away from a value that had stopped
+    // moving, and every remaining reading was rejected too. On O'Leary
+    // Mountain that flatlined 92% of the trail at 2,239 ft and reported 449 ft
+    // of climbing on a trail that gains about 3,200 — with a largest
+    // sample-to-sample step of 17.8 m, well under the 25 m threshold.
+    //
+    // 10 m per ~33 m of track is about a 30% grade: steep, and exactly what
+    // the real trail does where this first went wrong.
+    const points = makeTrack(200, { startAlt: 1000, altStep: 10 });
+    const { gain, max, min } = computeElevation(points);
+
+    // The track climbs 199 * 10 = 1,990 m. Loose on purpose — smoothing trims
+    // the ends, and the failure this guards against reported almost none of it.
+    expect(gain).toBeGreaterThan(1700);
+    expect(max - min).toBeGreaterThan(1700);
+  });
+
+  it('still replaces an isolated spike', () => {
+    // The behaviour the filter exists for, which the fix must not give up.
+    const clean = makeTrack(200, { startAlt: 1000, altStep: 2 });
+    const spiked = clean.map((point, i) =>
+      i === 100 ? { ...point, altitude: (point.altitude ?? 0) + 200 } : point,
+    );
+
+    const before = computeElevation(clean);
+    const after = computeElevation(spiked);
+
+    // A 200 m spike must not show up as 200 m of extra height.
+    expect(Math.abs(after.max - before.max)).toBeLessThan(20);
+  });
+
   it('computes gain for a steady climb', () => {
     const points = makeTrack(200, { startAlt: 200, altStep: 2 });
     const { gain, loss } = computeElevation(points);

--- a/src/utils/ride-stats.ts
+++ b/src/utils/ride-stats.ts
@@ -35,6 +35,12 @@ export const ELEVATION_DEAD_BAND = 3;
 // are replaced with the current EMA value before smoothing.
 // Must be high enough to allow sustained climbs (EMA lags on slopes).
 export const ELEVATION_SPIKE_THRESHOLD = 25;
+// How many consecutive readings may be dismissed as spikes before the series
+// is taken at face value. Losing satellite lock in a tunnel produces a short
+// burst — five points or so — while a hillside keeps going, so the run length
+// is what tells a real climb from bad data. Without a ceiling here, a filter
+// that holds its reference while rejecting will reject forever.
+export const ELEVATION_SPIKE_MAX_RUN = 5;
 // Minimum horizontal distance (meters) between deadband anchor updates.
 // Prevents counting altitude jitter while stopped or barely moving.
 export const ELEVATION_MIN_DISTANCE = 15;
@@ -153,13 +159,36 @@ function smoothAltitudes(points: { altitude: number | null }[]): number[] {
   const seedMedian = seedSlice[Math.floor(seedSlice.length / 2)];
   let spikeEma = seedMedian;
   const vals: number[] = [];
+  // How many readings in a row have been rejected. A burst of bad readings and
+  // a real climb look identical point by point — losing satellite lock in a
+  // tunnel ramps away from the truth exactly the way a hillside does. What
+  // separates them is how long it lasts, so the run length is what decides.
+  let rejectRun = 0;
   for (let i = 0; i < rawVals.length; i++) {
-    if (Math.abs(rawVals[i] - spikeEma) > ELEVATION_SPIKE_THRESHOLD) {
-      vals.push(spikeEma); // replace spike with current EMA
+    const deviates =
+      Math.abs(rawVals[i] - spikeEma) > ELEVATION_SPIKE_THRESHOLD;
+
+    if (deviates && rejectRun < ELEVATION_SPIKE_MAX_RUN) {
+      // Treat it as a spike: substitute, and **hold** the EMA where it is.
+      //
+      // Advancing it from the substituted value is what this used to do, and
+      // it is a latch: on a rejection the substitute *is* the EMA, so the
+      // update reduced to `ema = 0.3*ema + 0.7*ema` and the EMA froze
+      // permanently. Every later reading was then further than the threshold
+      // from a value that could no longer move, so it was rejected too. One
+      // rejection 7% into O'Leary Mountain flatlined the remaining 92% of the
+      // trail at 2,239 ft, reporting 449 ft of climbing on a trail that gains
+      // about 3,200.
+      vals.push(spikeEma);
+      rejectRun += 1;
     } else {
+      // Either a normal reading, or a deviation that has gone on too long to
+      // be noise — that is the ground, not a spike, so re-acquire.
       vals.push(rawVals[i]);
+      rejectRun = 0;
+      spikeEma =
+        SPIKE_EMA_ALPHA * rawVals[i] + (1 - SPIKE_EMA_ALPHA) * spikeEma;
     }
-    spikeEma = SPIKE_EMA_ALPHA * vals[i] + (1 - SPIKE_EMA_ALPHA) * spikeEma;
   }
 
   // Centered moving average


### PR DESCRIPTION
Stacked PR **1 of 2** · base `main`

`computeElevation`'s spike filter was deleting mountains.

It compares each altitude reading against a running EMA and replaces anything further away than `ELEVATION_SPIKE_THRESHOLD` (25 m). Two problems compounded:

1. On a sustained climb the EMA **lags** by roughly `step × (1-α)/α`. On a ~30% grade that lag alone crosses the threshold — with no spike anywhere in the data.
2. The reject branch advanced the EMA from the **substituted** value, so the update reduced to `ema = 0.3*ema + 0.7*ema`. It froze. The ground then climbed away from a value that could no longer move, so every later reading was rejected too.

On O'Leary Mountain, measured against the real DEM:

```
true range              : 2219 – 5131 ft
readings rejected       : 696 of 847 (82.2%)
first rejection at index: 62
EMA frozen from index   : 63  -> the last 784 samples all read 2239 ft
```

449 ft of climbing reported on a trail that gains about 3,200. The largest sample-to-sample step there is **17.8 m** — well under the 25 m threshold, which is what makes this a lag problem rather than a spike problem.

### The fix

Rejections are capped at `ELEVATION_SPIKE_MAX_RUN` consecutive samples, after which the series is taken at face value. A burst of bad readings is short; a hillside keeps going. Run length is the only thing that separates them. The reject branch now *holds* the EMA rather than advancing it from the substitute.

### Notes for review

- The subtle line is `ema = alpha*ema + (1-alpha)*ema` — a no-op that reads like an update. That's how the original looked correct.
- A first attempt at this tracked raw readings unconditionally and broke the existing `consecutive spikes (tunnel entry/exit) are suppressed` test. That test earned its keep; both behaviours are now covered.
- `computeElevation` is shared with **recorded ride stats**, so any ride with a sustained climb was being flattened the same way. Expect ride numbers to move.
- The new test reproduces the real failure shape and fails on the old code with `expected 9.866 to be greater than 1700`.