### PR TITLE
feat: curated lists for areas and organizations, editable admin theme

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -7,12 +7,18 @@ module.exports = {
     'biome format --write --no-errors-on-unmatched',
   ],
   '*.{json,jsonc}': (filenames) => {
-    // Filter out files in public directory
+    // Drop paths Biome is configured to ignore. Passing only ignored paths
+    // makes Biome exit non-zero ("No files were processed"), which fails the
+    // commit — and a commit touching just a generated migration does exactly
+    // that. --no-errors-on-unmatched covers the rest.
     const filtered = filenames.filter(
-      (f) => !f.startsWith('public/') && !f.includes('/public/'),
+      (f) =>
+        !f.startsWith('public/') &&
+        !f.includes('/public/') &&
+        !f.includes('/src/migrations/'),
     );
     return filtered.length > 0
-      ? [`biome format --write ${filtered.join(' ')}`]
+      ? [`biome format --write --no-errors-on-unmatched ${filtered.join(' ')}`]
       : [];
   },
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,9 @@ overwritten on the next save.
 - `src/payload/globals/Theme.ts` + `read/theme.ts` — admin appearance, editable
   at `/admin/globals/theme` and injected by the admin layout
 - `src/payload/collections/{Organizations,TrailAreas}.ts` — the options behind
-  the trail-org and recreation-area dropdowns
+  the trail-org and trail-complex dropdowns. The sidebar hierarchy is
+  **region → trail complex → trail**; "trail complex" is an admin **label**
+  only, the slug/table stay `trail-areas` and the app field stays `recArea`
 - `scripts/seed/{bend,chattanooga}.ts` — one script per city; their pipelines
   differ (Bend has osmIds + geometry, Chattanooga has neither), and **only Bend
   is seeded by default**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,9 @@ overwritten on the next save.
 - `src/payload/osm/build.ts` — orchestrates the above
 - `src/payload/components/OsmWayPicker.tsx` — the map picker admin field
 - `src/payload/read/trails.ts` — reads trails back out for the public map
+- `src/payload/globals/Theme.ts` + `read/theme.ts` — admin appearance, editable
+  at `/admin/globals/theme` and injected by the admin layout
+- `src/payload/collections/Organizations.ts` — the trail-org dropdown's options
 - `scripts/seed/{bend,chattanooga}.ts` — one script per city; their pipelines
   differ (Bend has osmIds + geometry, Chattanooga has neither), and **only Bend
   is seeded by default**
@@ -402,6 +405,14 @@ Things to know before touching it:
 - **Bulk writes must pass `context: { skipOsmRebuild: true }`**, or the
   `beforeChange` hook fires one Overpass request per row and gets the machine
   rate-limited. Trails with `geometrySource: 'imported'` are skipped anyway.
+- **Theme the admin with CSS variables, never Payload's selectors.** Defaults
+  live in `src/app/(payload)/custom.css`; the DB-backed overrides come from the
+  Theme global. Class names like `.btn__content` are internals that move between
+  releases. `--theme-elevation-*` resolves to a `--color-base-*` scale that dark
+  mode *inverts*, so retinting that ramp themes both modes at once.
+- **`getThemeCss` never throws**, same rule as `getCityTrails` — a theme row
+  must never lock anyone out of the admin. Its `customCss` is injected verbatim,
+  so `sanitizeCss` strips `<`/`>`; don't remove that.
 - **The project is ESM** (`"type": "module"` — Payload 3's CLI requires it). New
   root config files must be ESM or `.cjs`.
 - **There is no root `src/app/layout.tsx`, on purpose.** Payload's `RootLayout`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,8 @@ overwritten on the next save.
 - `src/payload/read/trails.ts` — reads trails back out for the public map
 - `src/payload/globals/Theme.ts` + `read/theme.ts` — admin appearance, editable
   at `/admin/globals/theme` and injected by the admin layout
-- `src/payload/collections/Organizations.ts` — the trail-org dropdown's options
+- `src/payload/collections/{Organizations,TrailAreas}.ts` — the options behind
+  the trail-org and recreation-area dropdowns
 - `scripts/seed/{bend,chattanooga}.ts` — one script per city; their pipelines
   differ (Bend has osmIds + geometry, Chattanooga has neither), and **only Bend
   is seeded by default**
@@ -405,6 +406,10 @@ Things to know before touching it:
 - **Bulk writes must pass `context: { skipOsmRebuild: true }`**, or the
   `beforeChange` hook fires one Overpass request per row and gets the machine
   rate-limited. Trails with `geometrySource: 'imported'` are skipped anyway.
+- **Group trails with `regionOf(trail)`** (`@/data/trail-region`), never
+  `regionFor(recArea)` directly. Trail areas carry an editable `region`;
+  `regionOf` prefers it and falls back to the city's hardcoded `REGION_MAP`, so
+  calling `regionFor` straight bypasses anything set in the admin.
 - **Theme the admin with CSS variables, never Payload's selectors.** Defaults
   live in `src/app/(payload)/custom.css`; the DB-backed overrides come from the
   Theme global. Class names like `.btn__content` are internals that move between

--- a/docs/guides/osm-trail-editor.md
+++ b/docs/guides/osm-trail-editor.md
@@ -229,8 +229,11 @@ deploy:
 
 | Collection | What it is |
 |---|---|
-| **Trail areas** | Recreation areas trails group under — "Phil's Trail Complex" |
+| **Trail complexes** | What trails group under — "Phil's Trail Complex", "Swampy Lakes" |
 | **Organizations** | The clubs and agencies that maintain trails — COTA, SORBA |
+
+The sidebar hierarchy is **region → trail complex → trail**, so a complex is the
+middle level and `region` is a field on it.
 
 Payload keeps both honest: renaming one updates every trail pointing at it, and
 it blocks deleting one still in use. Editors read the lists; admins curate them.
@@ -238,11 +241,11 @@ it blocks deleting one still in use. Editors read the lists; admins curate them.
 `recArea` used to be free text, which meant a typo silently created a new
 sidebar grouping that looked real.
 
-### Trail areas also move `region` out of code
+### Trail complexes also move `region` out of code
 
-The sidebar groups areas into regions ("Bend", "Cascade Lakes"), and that
-mapping was a hardcoded `REGION_MAP` per city — so adding an area meant editing
-TypeScript. It's now a field on the area.
+The sidebar groups complexes into regions ("Bend", "Cascade Lakes"), and that
+mapping was a hardcoded `REGION_MAP` per city — so adding a complex meant
+editing TypeScript. It's now a field on the complex.
 
 `regionOf(trail)` in `src/data/trail-region.ts` is what every grouping call site
 uses: it prefers the stored region and falls back to the built-in map when there
@@ -252,6 +255,18 @@ database the source of truth where it has an answer. **Group by `regionOf`, not
 
 The seed populates `region` from each city's `regionFor`, so the mapping arrives
 already filled in rather than blank.
+
+**Naming:** only the admin labels say "trail complex". The slug and table are
+still `trail-areas`, and the app-level field is still `recArea` — renaming those
+would mean a migration plus a sweep through the checked-in data files and the
+Python scripts that write them, for no user-visible gain.
+
+### City is hidden in the admin
+
+A deployment serves one city, so the `city` picker is hidden on trails,
+complexes, and organizations, defaulting to `activeCityId`. The column stays:
+`getCityTrails` filters on it, the seeds set it per city, and editor access is
+scoped by it. Removing `hidden` brings the picker back for a multi-city admin.
 
 ## Things that will trip you up
 

--- a/docs/guides/osm-trail-editor.md
+++ b/docs/guides/osm-trail-editor.md
@@ -221,16 +221,37 @@ unreachable one, or an unset global all return an empty string and the
 stylesheet defaults stand. Nobody should be locked out of the admin by a theme
 row.
 
-## Organizations
+## Reference collections
 
-Trail organizations — the clubs and agencies that maintain trails — are their
-own collection at `/admin/collections/organizations`, and Trails references one
-through a `relationship` field.
+Two fields on a trail are dropdowns backed by their own collections rather than
+free text or a hardcoded `select`, so their options are editable without a
+deploy:
 
-That's a collection rather than a hardcoded `select` so the options are editable
-without a deploy, and Payload keeps them honest: renaming an org updates every
-trail pointing at it, and it blocks deleting one still in use. Editors can read
-the list; only admins can change it.
+| Collection | What it is |
+|---|---|
+| **Trail areas** | Recreation areas trails group under — "Phil's Trail Complex" |
+| **Organizations** | The clubs and agencies that maintain trails — COTA, SORBA |
+
+Payload keeps both honest: renaming one updates every trail pointing at it, and
+it blocks deleting one still in use. Editors read the lists; admins curate them.
+
+`recArea` used to be free text, which meant a typo silently created a new
+sidebar grouping that looked real.
+
+### Trail areas also move `region` out of code
+
+The sidebar groups areas into regions ("Bend", "Cascade Lakes"), and that
+mapping was a hardcoded `REGION_MAP` per city — so adding an area meant editing
+TypeScript. It's now a field on the area.
+
+`regionOf(trail)` in `src/data/trail-region.ts` is what every grouping call site
+uses: it prefers the stored region and falls back to the built-in map when there
+isn't one. That keeps the checked-in data working unchanged while making the
+database the source of truth where it has an answer. **Group by `regionOf`, not
+`regionFor`** — the latter can't see the database.
+
+The seed populates `region` from each city's `regionFor`, so the mapping arrives
+already filled in rather than blank.
 
 ## Things that will trip you up
 

--- a/docs/guides/osm-trail-editor.md
+++ b/docs/guides/osm-trail-editor.md
@@ -188,6 +188,50 @@ within a minute without a rebuild. Trail edits are rare and the payload is a few
 hundred rows, so this serves a cached render and refreshes in the background
 rather than hitting the database per request.
 
+## Admin appearance
+
+Two layers, so the common case needs no code:
+
+1. **`src/app/(payload)/custom.css`** — the defaults. Sets CSS custom properties
+   only, never Payload's own selectors, because variables are a supported
+   surface and class names like `.btn__content` are internals that move between
+   releases. It's unlayered while Payload's styles live in
+   `@layer payload-default, payload`, so unlayered rules win and nothing needs
+   `!important`.
+2. **Settings → Theme** (`/admin/globals/theme`) — editable in the UI, stored in
+   the database, injected by the admin layout as variables that override the
+   stylesheet. Colour swatches, corner style, font, neutral tint, plus a custom
+   CSS escape hatch.
+
+Every theme field is optional: an unset field falls through to the stylesheet
+default, so clearing a field is how you reset it.
+
+**The one trick worth knowing:** `--theme-elevation-*` — the greys the whole UI
+is built from — all resolve to a `--color-base-*` scale, and Payload derives
+dark mode by *inverting* that scale. So retinting the base ramp once themes both
+modes coherently, which is why "neutral tint" is a single setting rather than
+two.
+
+`customCss` is injected verbatim, so `sanitizeCss` strips `<` and `>` — a stray
+`</style>` would otherwise turn styling into markup. It's admin-only, but
+"trusted input" is exactly how injection bugs get written.
+
+Like the trail reader, `getThemeCss` **never throws**: no database, an
+unreachable one, or an unset global all return an empty string and the
+stylesheet defaults stand. Nobody should be locked out of the admin by a theme
+row.
+
+## Organizations
+
+Trail organizations — the clubs and agencies that maintain trails — are their
+own collection at `/admin/collections/organizations`, and Trails references one
+through a `relationship` field.
+
+That's a collection rather than a hardcoded `select` so the options are editable
+without a deploy, and Payload keeps them honest: renaming an org updates every
+trail pointing at it, and it blocks deleting one still in use. Editors can read
+the list; only admins can change it.
+
 ## Things that will trip you up
 
 The full list lives in [CLAUDE.md](../../CLAUDE.md); this is the one that costs

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scripts/seed/bend.ts
+++ b/scripts/seed/bend.ts
@@ -26,6 +26,7 @@ import {
   report,
   repoRoot,
   run,
+  upsertArea,
   upsertTrail,
   type MultiLineString,
 } from './shared';
@@ -64,6 +65,9 @@ run(async () => {
     `bend: importing ${trails.length} trails (${geometry.size} geometries in ${GEOJSON})`,
   );
 
+  // Areas are created on first mention; the cache keeps that to one
+  // lookup per area rather than one per trail.
+  const areas = new Map<string, number>();
   let created = 0;
   let updated = 0;
   let withGeometry = 0;
@@ -81,7 +85,16 @@ run(async () => {
       continue;
     }
 
+    const areaId = await upsertArea(
+      payload,
+      'bend',
+      trail.recArea,
+      bendData.regionFor(trail.recArea),
+      areas,
+    );
+
     const result = await upsertTrail(payload, {
+      areaId,
       city: 'bend',
       geom,
       // Only trails that actually reference OSM ways can be rebuilt from them.

--- a/scripts/seed/chattanooga.ts
+++ b/scripts/seed/chattanooga.ts
@@ -24,7 +24,14 @@
  * Re-running is safe: rows match on (trailName, city) and update.
  */
 import { chattanoogaData } from '../../src/data/cities/chattanooga';
-import { connect, parseArgs, report, run, upsertTrail } from './shared';
+import {
+  connect,
+  parseArgs,
+  report,
+  run,
+  upsertArea,
+  upsertTrail,
+} from './shared';
 
 run(async () => {
   const { dryRun } = parseArgs(process.argv.slice(2));
@@ -35,6 +42,9 @@ run(async () => {
     `chattanooga: importing ${trails.length} trails (metadata only — geometry stays in the Mapbox tileset)`,
   );
 
+  // Areas are created on first mention; the cache keeps that to one
+  // lookup per area rather than one per trail.
+  const areas = new Map<string, number>();
   let created = 0;
   let updated = 0;
 
@@ -43,7 +53,16 @@ run(async () => {
       continue;
     }
 
+    const areaId = await upsertArea(
+      payload,
+      'chattanooga',
+      trail.recArea,
+      chattanoogaData.regionFor(trail.recArea),
+      areas,
+    );
+
     const result = await upsertTrail(payload, {
+      areaId,
       city: 'chattanooga',
       geom: null,
       geometrySource: 'imported',

--- a/scripts/seed/shared.ts
+++ b/scripts/seed/shared.ts
@@ -74,7 +74,55 @@ export interface SeedResult {
   withGeometry: number;
 }
 
+/**
+ * Creates the trail's recreation area if it doesn't exist yet, and returns its
+ * id. The source data carries the area as a plain string, so the first trail
+ * mentioning an area is what brings it into being.
+ *
+ * `region` comes from the city's own `regionFor`, which is the hardcoded map
+ * this collection exists to replace — seeding it means the mapping arrives in
+ * the database already populated rather than blank.
+ */
+export async function upsertArea(
+  payload: Payload,
+  city: CityId,
+  name: string,
+  region: string,
+  cache: Map<string, number>,
+): Promise<number> {
+  const key = `${city}:${name}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const existing = await payload.find({
+    collection: 'trail-areas',
+    depth: 0,
+    limit: 1,
+    pagination: false,
+    where: {
+      and: [{ name: { equals: name } }, { city: { equals: city } }],
+    },
+  });
+
+  const id =
+    existing.docs.length > 0
+      ? existing.docs[0].id
+      : (
+          await payload.create({
+            collection: 'trail-areas',
+            data: { city, name, region },
+          })
+        ).id;
+
+  cache.set(key, id);
+  return id;
+}
+
 export interface UpsertArgs {
+  /** Id of the trail's recreation area, from `upsertArea`. */
+  areaId: number;
   city: CityId;
   /** Geometry for this trail, when the city has any. */
   geom: MultiLineString | null;
@@ -97,10 +145,11 @@ export interface UpsertArgs {
  */
 export async function upsertTrail(
   payload: Payload,
-  { city, geom, geometrySource, trail }: UpsertArgs,
+  { areaId, city, geom, geometrySource, trail }: UpsertArgs,
 ): Promise<'created' | 'updated'> {
   const data = {
     _status: 'published' as const,
+    area: areaId,
     bounds: trail.defaultBounds ?? null,
     city,
     displayName: trail.displayName,
@@ -116,7 +165,6 @@ export async function upsertTrail(
     kind: kindFor(trail),
     osmIds: (trail.osmIds ?? null) as Trail['osmIds'],
     rating: ratingFor(trail),
-    recArea: trail.recArea,
     slug: trail.slug ?? null,
     trailName: trail.trailName,
   };

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,10 +1,12 @@
 import { OsmWayPicker as OsmWayPicker_15a0782e82130938182c92ec3ead337e } from '@/payload/components/OsmWayPicker'
 import { OsmBuildReport as OsmBuildReport_7fae1a551cc8eca6bdac5f4c01e2bf46 } from '@/payload/components/OsmBuildReport'
+import { ColorField as ColorField_9867b71f70a870a7cadc249fe18ef53e } from '@/payload/components/ColorField'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
   "@/payload/components/OsmWayPicker#OsmWayPicker": OsmWayPicker_15a0782e82130938182c92ec3ead337e,
   "@/payload/components/OsmBuildReport#OsmBuildReport": OsmBuildReport_7fae1a551cc8eca6bdac5f4c01e2bf46,
+  "@/payload/components/ColorField#ColorField": ColorField_9867b71f70a870a7cadc249fe18ef53e,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/app/(payload)/custom.css
+++ b/src/app/(payload)/custom.css
@@ -1,0 +1,119 @@
+/**
+ * Admin theming.
+ *
+ * Payload's admin is themed through CSS custom properties rather than by
+ * overriding component styles, so this file sets variables and almost nothing
+ * else. That matters for upgrades: variables are a supported surface, whereas
+ * selectors like `.btn--style-primary .btn__content` are internals that move.
+ *
+ * Two things make this cheap:
+ *
+ *  1. `--theme-elevation-*` (the greys everything is built from) all resolve to
+ *     a `--color-base-*` scale, and dark mode *inverts* that scale — elevation-0
+ *     is base-0 in light and base-900 in dark. So retinting the base scale once
+ *     re-tints both themes coherently, with Payload's own inversion intact.
+ *  2. This stylesheet is unlayered, and Payload's own styles live in
+ *     `@layer payload-default, payload`. Unlayered rules beat layered ones in
+ *     the cascade, so nothing here needs `!important`.
+ */
+
+:root {
+  /* --- Neutrals -----------------------------------------------------------
+   * Payload ships a pure grey ramp (r = g = b). These are the same lightness
+   * steps shifted slightly cool, so the chrome sits with the app's teal
+   * (#1a434e) instead of fighting it. Keeping the steps means contrast ratios
+   * carry over unchanged.
+   */
+  --color-base-0: rgb(255, 255, 255);
+  --color-base-50: rgb(246, 248, 249);
+  --color-base-100: rgb(238, 241, 243);
+  --color-base-150: rgb(227, 232, 234);
+  --color-base-200: rgb(214, 220, 223);
+  --color-base-300: rgb(184, 194, 198);
+  --color-base-400: rgb(148, 161, 166);
+  --color-base-500: rgb(111, 125, 131);
+  --color-base-600: rgb(86, 98, 104);
+  --color-base-700: rgb(63, 74, 79);
+  --color-base-800: rgb(42, 51, 56);
+  --color-base-850: rgb(31, 39, 43);
+  --color-base-900: rgb(20, 26, 29);
+  --color-base-950: rgb(10, 14, 16);
+  --color-base-1000: rgb(0, 0, 0);
+
+  /* --- Shape --------------------------------------------------------------
+   * Payload's 3/4/8px corners read as older UI. Softer radii are the single
+   * biggest visual change here.
+   */
+  --style-radius-s: 6px;
+  --style-radius-m: 10px;
+  --style-radius-l: 16px;
+
+  /* Geist, loaded by the admin layout. The fallback stack matches Payload's
+   * default so nothing shifts if the font fails to load. */
+  --font-body:
+    var(--font-geist-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo,
+    monospace;
+
+  /* Brand lime. Used only for focus, which keeps it as an accent rather than
+   * something competing with the content. */
+  --brand-accent: #c3f44d;
+  --brand-deep: #1a434e;
+}
+
+/* Focus ring — brand lime, and thick enough to be unmissable on both themes.
+ * Payload drives every focus outline through this one variable. */
+:root {
+  --accessibility-outline: 2px solid var(--brand-accent);
+  --accessibility-outline-offset: 2px;
+}
+
+/* Smooth the fonts the way the public app does, so the two don't look like
+ * different products. */
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Slightly tighter, more modern heading rhythm. Payload's defaults are set for
+ * long-form prose; an admin is mostly labels and short strings. */
+h1,
+h2,
+h3,
+h4 {
+  letter-spacing: -0.015em;
+}
+
+/* The login screen is the first thing anyone sees, and by default it's a bare
+ * white page. A soft brand-tinted wash costs nothing and makes it look
+ * deliberate. */
+.login {
+  background:
+    radial-gradient(
+      ellipse at top,
+      color-mix(in srgb, var(--brand-accent) 12%, transparent),
+      transparent 60%
+    ),
+    var(--theme-bg);
+}
+
+/* Payload renders the whole app inside a scroll container; a thin styled
+ * scrollbar reads as more finished than the OS default on desktop. */
+@supports selector(::-webkit-scrollbar) {
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--theme-elevation-200);
+    border: 2px solid var(--theme-bg);
+    border-radius: 999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--theme-elevation-300);
+  }
+}

--- a/src/app/(payload)/layout.tsx
+++ b/src/app/(payload)/layout.tsx
@@ -5,10 +5,32 @@
  */
 import type { ServerFunctionClient } from 'payload';
 import { handleServerFunctions, RootLayout } from '@payloadcms/next/layouts';
+import localFont from 'next/font/local';
 import config from '@payload-config';
+import { getThemeCss } from '@/payload/read/theme';
 import { importMap } from './admin/importMap';
 
 import '@payloadcms/next/css';
+// Must come after Payload's stylesheet — see the note in custom.css about why
+// this needs no !important.
+import './custom.css';
+
+// The same self-hosted Geist the public app uses, so the admin doesn't look
+// like a different product. Loaded here rather than shared with (frontend)
+// because the two route groups are separate trees with no common layout.
+const geistSans = localFont({
+  display: 'swap',
+  src: '../(frontend)/fonts/Geist-Variable.woff2',
+  variable: '--font-geist-sans',
+  weight: '100 900',
+});
+
+const geistMono = localFont({
+  display: 'swap',
+  src: '../(frontend)/fonts/GeistMono-Variable.woff2',
+  variable: '--font-geist-mono',
+  weight: '100 900',
+});
 
 type Args = {
   children: React.ReactNode;
@@ -23,13 +45,34 @@ const serverFunction: ServerFunctionClient = async (args) => {
   });
 };
 
-export default function Layout({ children }: Args) {
+export default async function Layout({ children }: Args) {
+  // The saved theme, as CSS custom properties. Rendered after custom.css so a
+  // theme edited in the admin wins over the stylesheet defaults; empty when
+  // nothing is saved or the database is unreachable.
+  const themeCss = await getThemeCss();
+
   return (
     <RootLayout
+      // htmlProps is the supported way to reach Payload's <html>; it renders
+      // that element itself, so the font variables have to go through here.
+      htmlProps={{ className: `${geistSans.variable} ${geistMono.variable}` }}
       config={config}
       importMap={importMap}
       serverFunction={serverFunction}
     >
+      {themeCss && (
+        // Arrives in the streamed RSC payload rather than the initial <head>:
+        // this sits inside Payload's client provider, so React won't hoist it
+        // even given `href`/`precedence` (tried — the props don't survive).
+        // That's fine here, because the admin renders nothing until hydration,
+        // so there is no paint for a wrong theme to flash on. Don't "fix" it
+        // with a CSS `@import`, which has to come first in a file and would
+        // therefore lose to custom.css rather than override it.
+        //
+        // Content is custom properties only; see sanitizeCss in read/theme.ts
+        // for why it cannot close its own <style> element.
+        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
+      )}
       {children}
     </RootLayout>
   );

--- a/src/components/sidebar/MountainBikeTrails.db.test.tsx
+++ b/src/components/sidebar/MountainBikeTrails.db.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { setMountainBikeTrails } from '@/data/trail-source';
+import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
+import { MountainBikeTrails } from './MountainBikeTrails';
+
+/**
+ * Regression test for trails arriving *after* this module is imported.
+ *
+ * The sibling test file mocks `getMountainBikeTrails`, so it passes whether the
+ * grouping runs at import time or during render. This one uses the real
+ * trail-source and sets trails the way the server does — which is the only way
+ * to catch the grouping being computed at module scope, where it captures the
+ * checked-in fallback data and never sees a database row.
+ */
+
+const props = {
+  onAreaSelect: vi.fn(),
+  onTrailSelect: vi.fn(),
+  selectedTrail: null,
+};
+
+function trail(overrides: Partial<MountainBikeTrail>): MountainBikeTrail {
+  return {
+    color: '#16A34A',
+    displayName: 'From Database',
+    icon: {} as MountainBikeTrail['icon'],
+    rating: 'easy',
+    recArea: 'Database Area',
+    trailName: 'From Database',
+    ...overrides,
+  } as MountainBikeTrail;
+}
+
+describe('MountainBikeTrails with database trails', () => {
+  it('renders the area and region set after the module was imported', () => {
+    // Exactly what HomeClient does with the server's props. Two areas, because
+    // the sidebar deliberately hides the area heading when a region holds only
+    // one — it would just repeat the region.
+    setMountainBikeTrails([
+      trail({
+        displayName: 'One',
+        recArea: 'Database Area',
+        region: 'Database Region',
+        trailName: 'One',
+      }),
+      trail({
+        displayName: 'Two',
+        recArea: 'Second Area',
+        region: 'Database Region',
+        trailName: 'Two',
+      }),
+    ]);
+
+    render(<MountainBikeTrails {...props} />);
+
+    // The region heading comes from the area's stored region; it would be
+    // absent if the grouping had been computed at import time.
+    expect(screen.getByText('Database Region')).toBeInTheDocument();
+
+    // Areas sit inside a collapsed region, so expand it to reach them.
+    fireEvent.click(screen.getByText('Database Region'));
+    expect(screen.getByText('Database Area')).toBeInTheDocument();
+    expect(screen.getByText('Second Area')).toBeInTheDocument();
+  });
+
+  it('collapses the area heading when a region holds only one', () => {
+    // Existing behaviour worth pinning: a lone area heading would just repeat
+    // the region above it, so the trails are listed directly.
+    setMountainBikeTrails([
+      trail({
+        displayName: 'Only',
+        recArea: 'Lone Area',
+        region: 'Lone Region',
+        trailName: 'Only',
+      }),
+    ]);
+
+    render(<MountainBikeTrails {...props} />);
+    fireEvent.click(screen.getByText('Lone Region'));
+
+    expect(screen.getByText('Only')).toBeInTheDocument();
+    expect(screen.queryByText('Lone Area')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sidebar/MountainBikeTrails.tsx
+++ b/src/components/sidebar/MountainBikeTrails.tsx
@@ -5,7 +5,7 @@ import {
   faChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
 import { cn } from '@/lib/utils';
-import { regionFor } from '@/data/geo_data';
+import { regionOf } from '@/data/trail-region';
 import { getMountainBikeTrails } from '@/data/trail-source';
 import type { MountainBikeTrailsProps } from './types';
 import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
@@ -13,7 +13,7 @@ import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
 function groupTrailsByRegionAndArea() {
   const grouped = new Map<string, Map<string, MountainBikeTrail[]>>();
   for (const trail of getMountainBikeTrails()) {
-    const region = regionFor(trail.recArea);
+    const region = regionOf(trail);
     const { recArea } = trail;
     if (!grouped.has(region)) {
       grouped.set(region, new Map());
@@ -127,7 +127,7 @@ export function MountainBikeTrails({
     const q = searchQuery.trim().toLowerCase();
     if (!q) return null;
     return getMountainBikeTrails().filter((trail) => {
-      const region = regionFor(trail.recArea);
+      const region = regionOf(trail);
       return (
         trail.trailName.toLowerCase().includes(q) ||
         trail.displayName.toLowerCase().includes(q) ||
@@ -144,7 +144,7 @@ export function MountainBikeTrails({
       (t) => t.trailName === selectedTrail,
     );
     if (!trail) return;
-    const region = regionFor(trail.recArea);
+    const region = regionOf(trail);
     setExpandedRegions((prev) => {
       if (prev.has(region)) return prev;
       return new Set(prev).add(region);

--- a/src/components/sidebar/MountainBikeTrails.tsx
+++ b/src/components/sidebar/MountainBikeTrails.tsx
@@ -10,6 +10,15 @@ import { getMountainBikeTrails } from '@/data/trail-source';
 import type { MountainBikeTrailsProps } from './types';
 import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
 
+/**
+ * Groups the current trail list region -> area -> trails, with a trail count
+ * per region.
+ *
+ * Called during render rather than at module scope: trails arrive from the
+ * database via `setMountainBikeTrails` while this component's module is being
+ * imported, so anything computed at import time captures the checked-in
+ * fallback data and never sees a database row.
+ */
 function groupTrailsByRegionAndArea() {
   const grouped = new Map<string, Map<string, MountainBikeTrail[]>>();
   for (const trail of getMountainBikeTrails()) {
@@ -25,16 +34,15 @@ function groupTrailsByRegionAndArea() {
     }
     areas.get(recArea)?.push(trail);
   }
-  return grouped;
-}
 
-const regionGroups = groupTrailsByRegionAndArea();
+  const counts = new Map<string, number>();
+  for (const [region, areas] of grouped) {
+    let count = 0;
+    for (const trails of areas.values()) count += trails.length;
+    counts.set(region, count);
+  }
 
-const regionTrailCounts = new Map<string, number>();
-for (const [region, areas] of regionGroups) {
-  let count = 0;
-  for (const trails of areas.values()) count += trails.length;
-  regionTrailCounts.set(region, count);
+  return { counts, grouped };
 }
 
 function toggleSet(
@@ -121,6 +129,13 @@ export function MountainBikeTrails({
   const [expandedAreas, setExpandedAreas] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
+
+  // The trail list is fixed for the life of the page, so this runs once —
+  // but it has to run during render, not at import. See the note above.
+  const { counts: regionTrailCounts, grouped: regionGroups } = useMemo(
+    () => groupTrailsByRegionAndArea(),
+    [],
+  );
 
   // Filter trails by search query (matches trail name, area, or region)
   const searchResults = useMemo(() => {

--- a/src/data/mountain-bike-trails.ts
+++ b/src/data/mountain-bike-trails.ts
@@ -20,6 +20,10 @@ export interface MountainBikeTrail {
   trailName: string; // Trail property value from Mapbox features
   displayName: string; // Human-friendly display name
   recArea: string; // Recreation area grouping
+  // Sidebar heading this trail's area sits under. Set when the area came from
+  // the database and carries one; otherwise `regionFor` derives it from the
+  // built-in REGION_MAP.
+  region?: string;
   rating: string; // "easy" | "intermediate" | "advanced" | "expert" | ""
   color: string; // Display color
   icon: IconDefinition;

--- a/src/data/trail-region.test.ts
+++ b/src/data/trail-region.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// regionFor is the city's hardcoded REGION_MAP — the thing the trail-areas
+// collection exists to make editable. Stubbed so the fallback is unambiguous.
+vi.mock('@/data/geo_data', () => ({
+  regionFor: (recArea: string) =>
+    recArea === 'Known Area' ? 'Built-in Region' : 'Other',
+}));
+
+const { regionOf } = await import('./trail-region');
+type Trail = Parameters<typeof regionOf>[0];
+
+function trail(overrides: Partial<Trail>): Trail {
+  return {
+    color: '#000000',
+    displayName: 'A Trail',
+    icon: {} as Trail['icon'],
+    rating: '',
+    recArea: 'Known Area',
+    trailName: 'A Trail',
+    ...overrides,
+  } as Trail;
+}
+
+describe('regionOf', () => {
+  it('prefers the region stored on the trail', () => {
+    // This is the payoff: an editor changes the area's region in the admin and
+    // the sidebar regroups, with no deploy.
+    expect(regionOf(trail({ region: 'From The Database' }))).toBe(
+      'From The Database',
+    );
+  });
+
+  it('falls back to the built-in map when no region is stored', () => {
+    // Trails from the checked-in data have no region at all.
+    expect(regionOf(trail({}))).toBe('Built-in Region');
+  });
+
+  it('falls back when the stored region is empty', () => {
+    // The field is optional, so an area saved without one yields ''. That must
+    // behave like "unset", not group everything under a blank heading.
+    expect(regionOf(trail({ region: '' }))).toBe('Built-in Region');
+  });
+});

--- a/src/data/trail-region.ts
+++ b/src/data/trail-region.ts
@@ -1,0 +1,16 @@
+import { regionFor } from './geo_data';
+import type { MountainBikeTrail } from './mountain-bike-trails';
+
+/**
+ * The sidebar heading a trail sits under.
+ *
+ * Prefers the region stored on the trail's recreation area, which is editable
+ * in the admin, and falls back to the city's built-in `REGION_MAP` for trails
+ * that came from the checked-in data or whose area has no region set.
+ *
+ * Every grouping call site should use this rather than `regionFor` directly,
+ * so an area's region can be changed without a deploy.
+ */
+export function regionOf(trail: MountainBikeTrail): string {
+  return trail.region || regionFor(trail.recArea);
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -68,6 +68,7 @@ export interface Config {
   blocks: {};
   collections: {
     trails: Trail;
+    'trail-areas': TrailArea;
     organizations: Organization;
     users: User;
     'payload-kv': PayloadKv;
@@ -78,6 +79,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     trails: TrailsSelect<false> | TrailsSelect<true>;
+    'trail-areas': TrailAreasSelect<false> | TrailAreasSelect<true>;
     organizations: OrganizationsSelect<false> | OrganizationsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -147,9 +149,9 @@ export interface Trail {
    */
   organization?: (number | null) | Organization;
   /**
-   * Recreation area grouping, e.g. "Stringers Ridge".
+   * Recreation area. Manage the list under Map content → Trail areas.
    */
-  recArea: string;
+  area: number | TrailArea;
   rating: 'easy' | 'intermediate' | 'advanced' | 'expert' | 'unrated';
   /**
    * Drives the line color and marker icon. Colors are derived from kind + rating rather than stored, so a palette change is one code edit.
@@ -255,6 +257,30 @@ export interface Organization {
   createdAt: string;
 }
 /**
+ * Recreation areas trails are grouped under. Anything added here becomes selectable on a trail.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-areas".
+ */
+export interface TrailArea {
+  id: number;
+  /**
+   * As shown in the sidebar, e.g. "Phil's Trail Complex".
+   */
+  name: string;
+  city: 'chattanooga' | 'bend';
+  /**
+   * The heading this area sits under in the sidebar, e.g. "Bend" or "Lookout Mountain". Leave blank to use the built-in mapping.
+   */
+  region?: string | null;
+  /**
+   * Optional.
+   */
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
@@ -312,6 +338,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'trails';
         value: number | Trail;
+      } | null)
+    | ({
+        relationTo: 'trail-areas';
+        value: number | TrailArea;
       } | null)
     | ({
         relationTo: 'organizations';
@@ -373,7 +403,7 @@ export interface TrailsSelect<T extends boolean = true> {
   trailName?: T;
   slug?: T;
   organization?: T;
-  recArea?: T;
+  area?: T;
   rating?: T;
   kind?: T;
   osmIds?: T;
@@ -390,6 +420,18 @@ export interface TrailsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-areas_select".
+ */
+export interface TrailAreasSelect<T extends boolean = true> {
+  name?: T;
+  city?: T;
+  region?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -149,7 +149,7 @@ export interface Trail {
    */
   organization?: (number | null) | Organization;
   /**
-   * Recreation area. Manage the list under Map content → Trail areas.
+   * Manage the list under Map content → Trail complexes.
    */
   area: number | TrailArea;
   rating: 'easy' | 'intermediate' | 'advanced' | 'expert' | 'unrated';
@@ -241,9 +241,6 @@ export interface Organization {
    * e.g. "COTA". Shown where space is tight.
    */
   abbreviation?: string | null;
-  /**
-   * Optional. Leave blank for an organization that works across several cities.
-   */
   city?: ('chattanooga' | 'bend') | null;
   /**
    * Where riders can find them — membership, trail reports.
@@ -257,7 +254,7 @@ export interface Organization {
   createdAt: string;
 }
 /**
- * Recreation areas trails are grouped under. Anything added here becomes selectable on a trail.
+ * Trail complexes trails are grouped under, and the region each sits in. Anything added here becomes selectable on a trail.
  *
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "trail-areas".
@@ -270,7 +267,7 @@ export interface TrailArea {
   name: string;
   city: 'chattanooga' | 'bend';
   /**
-   * The heading this area sits under in the sidebar, e.g. "Bend" or "Lookout Mountain". Leave blank to use the built-in mapping.
+   * The heading this complex sits under in the sidebar — the level above it, e.g. "Bend" or "Cascade Lakes". Leave blank to use the built-in mapping.
    */
   region?: string | null;
   /**

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -68,6 +68,7 @@ export interface Config {
   blocks: {};
   collections: {
     trails: Trail;
+    organizations: Organization;
     users: User;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
@@ -77,6 +78,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     trails: TrailsSelect<false> | TrailsSelect<true>;
+    organizations: OrganizationsSelect<false> | OrganizationsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -87,8 +89,12 @@ export interface Config {
     defaultIDType: number;
   };
   fallbackLocale: null;
-  globals: {};
-  globalsSelect: {};
+  globals: {
+    theme: Theme;
+  };
+  globalsSelect: {
+    theme: ThemeSelect<false> | ThemeSelect<true>;
+  };
   locale: null;
   widgets: {
     collections: CollectionsWidget;
@@ -136,6 +142,10 @@ export interface Trail {
    * Canonical slug when it differs from the trail name. Also names the elevation profile JSON.
    */
   slug?: string | null;
+  /**
+   * Who builds and maintains this trail. Manage the list under Map content → Organizations.
+   */
+  organization?: (number | null) | Organization;
   /**
    * Recreation area grouping, e.g. "Stringers Ridge".
    */
@@ -214,6 +224,37 @@ export interface Trail {
   _status?: ('draft' | 'published') | null;
 }
 /**
+ * The clubs and agencies that maintain trails. Anything added here becomes selectable on a trail.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "organizations".
+ */
+export interface Organization {
+  id: number;
+  /**
+   * Full name, e.g. "Central Oregon Trail Alliance".
+   */
+  name: string;
+  /**
+   * e.g. "COTA". Shown where space is tight.
+   */
+  abbreviation?: string | null;
+  /**
+   * Optional. Leave blank for an organization that works across several cities.
+   */
+  city?: ('chattanooga' | 'bend') | null;
+  /**
+   * Where riders can find them — membership, trail reports.
+   */
+  url?: string | null;
+  /**
+   * A sentence or two. Optional.
+   */
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
@@ -273,6 +314,10 @@ export interface PayloadLockedDocument {
         value: number | Trail;
       } | null)
     | ({
+        relationTo: 'organizations';
+        value: number | Organization;
+      } | null)
+    | ({
         relationTo: 'users';
         value: number | User;
       } | null);
@@ -327,6 +372,7 @@ export interface TrailsSelect<T extends boolean = true> {
   city?: T;
   trailName?: T;
   slug?: T;
+  organization?: T;
   recArea?: T;
   rating?: T;
   kind?: T;
@@ -344,6 +390,19 @@ export interface TrailsSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "organizations_select".
+ */
+export interface OrganizationsSelect<T extends boolean = true> {
+  name?: T;
+  abbreviation?: T;
+  city?: T;
+  url?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -409,6 +468,50 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   batch?: T;
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * How the admin looks. Changes apply on the next page load. Clear a field to fall back to the default.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "theme".
+ */
+export interface Theme {
+  id: number;
+  /**
+   * Focus rings and highlights. Default #c3f44d.
+   */
+  accentColor?: string | null;
+  /**
+   * Deep brand colour. Default #1a434e.
+   */
+  deepColor?: string | null;
+  /**
+   * The cast of the greys everything is built from. Applies to both light and dark mode, because Payload derives dark mode by inverting the same scale.
+   */
+  neutralTint?: ('cool' | 'neutral' | 'warm') | null;
+  cornerStyle?: ('sharp' | 'soft' | 'round') | null;
+  fontFamily?: ('geist' | 'system' | 'serif') | null;
+  /**
+   * Escape hatch for anything the fields above do not cover. Injected verbatim into the admin. Admins only — treat it as code.
+   */
+  customCss?: string | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "theme_select".
+ */
+export interface ThemeSelect<T extends boolean = true> {
+  accentColor?: T;
+  deepColor?: T;
+  neutralTint?: T;
+  cornerStyle?: T;
+  fontFamily?: T;
+  customCss?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -2,8 +2,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { postgresAdapter } from '@payloadcms/db-postgres';
 import { buildConfig } from 'payload';
+import { Organizations } from './payload/collections/Organizations';
 import { Trails } from './payload/collections/Trails';
 import { Users } from './payload/collections/Users';
+import { Theme } from './payload/globals/Theme';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -22,7 +24,8 @@ export default buildConfig({
       titleSuffix: '— Open Bike Map',
     },
   },
-  collections: [Trails, Users],
+  collections: [Trails, Organizations, Users],
+  globals: [Theme],
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { postgresAdapter } from '@payloadcms/db-postgres';
 import { buildConfig } from 'payload';
 import { Organizations } from './payload/collections/Organizations';
+import { TrailAreas } from './payload/collections/TrailAreas';
 import { Trails } from './payload/collections/Trails';
 import { Users } from './payload/collections/Users';
 import { Theme } from './payload/globals/Theme';
@@ -24,7 +25,7 @@ export default buildConfig({
       titleSuffix: '— Open Bike Map',
     },
   },
-  collections: [Trails, Organizations, Users],
+  collections: [Trails, TrailAreas, Organizations, Users],
   globals: [Theme],
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/src/payload/collections/Organizations.ts
+++ b/src/payload/collections/Organizations.ts
@@ -1,0 +1,96 @@
+import type { CollectionConfig } from 'payload';
+
+/**
+ * Trail organizations — the clubs and agencies that build and maintain trails
+ * (COTA in Bend, SORBA around Chattanooga, land managers, and so on).
+ *
+ * This exists as its own collection rather than a hardcoded `select` on Trails
+ * so the options are editable in the admin, at
+ * `/admin/collections/organizations`, without a deploy. Trails reference it
+ * through a `relationship` field, which Payload renders as a searchable
+ * dropdown and keeps referentially honest — renaming an org here updates every
+ * trail pointing at it, and Payload blocks deleting one that's still in use.
+ */
+export const Organizations: CollectionConfig = {
+  slug: 'organizations',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'abbreviation', 'city', 'url'],
+    description:
+      'The clubs and agencies that maintain trails. Anything added here becomes selectable on a trail.',
+    group: 'Map content',
+    listSearchableFields: ['name', 'abbreviation'],
+  },
+  access: {
+    // Options are shared reference data, so any signed-in editor may read them,
+    // but changing the list is an admin decision.
+    create: ({ req }) => req.user?.role === 'admin',
+    delete: ({ req }) => req.user?.role === 'admin',
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+          unique: true,
+          admin: {
+            description: 'Full name, e.g. "Central Oregon Trail Alliance".',
+            width: '65%',
+          },
+        },
+        {
+          name: 'abbreviation',
+          type: 'text',
+          admin: {
+            description: 'e.g. "COTA". Shown where space is tight.',
+            width: '35%',
+          },
+        },
+      ],
+    },
+    {
+      name: 'city',
+      type: 'select',
+      options: [
+        { label: 'Chattanooga', value: 'chattanooga' },
+        { label: 'Bend', value: 'bend' },
+      ],
+      admin: {
+        description:
+          'Optional. Leave blank for an organization that works across several cities.',
+      },
+    },
+    {
+      name: 'url',
+      type: 'text',
+      admin: {
+        description: 'Where riders can find them — membership, trail reports.',
+      },
+      validate: (value: unknown): string | true => {
+        if (!value) {
+          return true;
+        }
+        try {
+          const { protocol } = new URL(String(value));
+          return protocol === 'http:' || protocol === 'https:'
+            ? true
+            : 'Must be an http or https URL.';
+        } catch {
+          return 'Must be a full URL, including https://';
+        }
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: {
+        description: 'A sentence or two. Optional.',
+      },
+    },
+  ],
+};

--- a/src/payload/collections/Organizations.ts
+++ b/src/payload/collections/Organizations.ts
@@ -15,7 +15,7 @@ export const Organizations: CollectionConfig = {
   slug: 'organizations',
   admin: {
     useAsTitle: 'name',
-    defaultColumns: ['name', 'abbreviation', 'city', 'url'],
+    defaultColumns: ['name', 'abbreviation', 'url'],
     description:
       'The clubs and agencies that maintain trails. Anything added here becomes selectable on a trail.',
     group: 'Map content',
@@ -60,10 +60,9 @@ export const Organizations: CollectionConfig = {
         { label: 'Chattanooga', value: 'chattanooga' },
         { label: 'Bend', value: 'bend' },
       ],
-      admin: {
-        description:
-          'Optional. Leave blank for an organization that works across several cities.',
-      },
+      // Hidden: a deployment serves one city. Left blank an organization
+      // applies everywhere, which is the right default here.
+      admin: { hidden: true },
     },
     {
       name: 'url',

--- a/src/payload/collections/TrailAreas.ts
+++ b/src/payload/collections/TrailAreas.ts
@@ -1,0 +1,76 @@
+import type { CollectionConfig } from 'payload';
+
+/**
+ * Recreation areas — the places trails are grouped under in the sidebar
+ * ("Phil's Trail Complex", "Stringers Ridge").
+ *
+ * This was free text on Trails, which meant a typo silently created a new
+ * grouping that looked real in the UI. As a collection the options are picked,
+ * not typed, and renaming one updates every trail at once.
+ *
+ * It also moves `region` out of code. The sidebar groups areas into regions
+ * ("Bend", "Cascade Lakes"), and that mapping lived in a hardcoded `REGION_MAP`
+ * per city — so adding an area meant editing TypeScript. Storing it here makes
+ * it editable, and the app falls back to the hardcoded map for any trail
+ * without one.
+ */
+export const TrailAreas: CollectionConfig = {
+  slug: 'trail-areas',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'region', 'city'],
+    description:
+      'Recreation areas trails are grouped under. Anything added here becomes selectable on a trail.',
+    group: 'Map content',
+    listSearchableFields: ['name', 'region'],
+  },
+  access: {
+    // Shared reference data: any signed-in editor may read, admins curate.
+    create: ({ req }) => req.user?.role === 'admin',
+    delete: ({ req }) => req.user?.role === 'admin',
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+          index: true,
+          admin: {
+            description:
+              'As shown in the sidebar, e.g. "Phil\'s Trail Complex".',
+            width: '60%',
+          },
+        },
+        {
+          name: 'city',
+          type: 'select',
+          required: true,
+          options: [
+            { label: 'Chattanooga', value: 'chattanooga' },
+            { label: 'Bend', value: 'bend' },
+          ],
+          admin: { width: '40%' },
+        },
+      ],
+    },
+    {
+      name: 'region',
+      type: 'text',
+      index: true,
+      admin: {
+        description:
+          'The heading this area sits under in the sidebar, e.g. "Bend" or "Lookout Mountain". Leave blank to use the built-in mapping.',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: { description: 'Optional.' },
+    },
+  ],
+};

--- a/src/payload/collections/TrailAreas.ts
+++ b/src/payload/collections/TrailAreas.ts
@@ -1,26 +1,38 @@
 import type { CollectionConfig } from 'payload';
+import { activeCityId } from '@/config/map.config';
 
 /**
- * Recreation areas — the places trails are grouped under in the sidebar
- * ("Phil's Trail Complex", "Stringers Ridge").
+ * Trail complexes — the places trails are grouped under in the sidebar
+ * ("Phil's Trail Complex", "Swampy Lakes", "Stringers Ridge").
+ *
+ * The sidebar hierarchy is **region → trail complex → trail**, and this is the
+ * middle level.
  *
  * This was free text on Trails, which meant a typo silently created a new
  * grouping that looked real in the UI. As a collection the options are picked,
  * not typed, and renaming one updates every trail at once.
  *
- * It also moves `region` out of code. The sidebar groups areas into regions
+ * It also moves `region` out of code. The sidebar groups complexes into regions
  * ("Bend", "Cascade Lakes"), and that mapping lived in a hardcoded `REGION_MAP`
- * per city — so adding an area meant editing TypeScript. Storing it here makes
- * it editable, and the app falls back to the hardcoded map for any trail
+ * per city — so adding a complex meant editing TypeScript. Storing it here
+ * makes it editable, and the app falls back to the hardcoded map for anything
  * without one.
+ *
+ * **The slug and table are still `trail-areas`.** Only the labels changed, so
+ * the rename needed no migration; `recArea` is likewise still the field name
+ * carried through the app and the checked-in data files.
  */
 export const TrailAreas: CollectionConfig = {
   slug: 'trail-areas',
+  labels: {
+    plural: 'Trail complexes',
+    singular: 'Trail complex',
+  },
   admin: {
     useAsTitle: 'name',
-    defaultColumns: ['name', 'region', 'city'],
+    defaultColumns: ['name', 'region'],
     description:
-      'Recreation areas trails are grouped under. Anything added here becomes selectable on a trail.',
+      'Trail complexes trails are grouped under, and the region each sits in. Anything added here becomes selectable on a trail.',
     group: 'Map content',
     listSearchableFields: ['name', 'region'],
   },
@@ -40,21 +52,26 @@ export const TrailAreas: CollectionConfig = {
           type: 'text',
           required: true,
           index: true,
+          label: 'Complex name',
           admin: {
             description:
               'As shown in the sidebar, e.g. "Phil\'s Trail Complex".',
-            width: '60%',
+            width: '100%',
           },
         },
         {
           name: 'city',
           type: 'select',
           required: true,
+          defaultValue: activeCityId,
           options: [
             { label: 'Chattanooga', value: 'chattanooga' },
             { label: 'Bend', value: 'bend' },
           ],
-          admin: { width: '40%' },
+          // Hidden: a deployment serves one city. The column stays so
+          // complexes remain scoped per city and a multi-city admin only needs
+          // `hidden` removed.
+          admin: { hidden: true },
         },
       ],
     },
@@ -64,7 +81,7 @@ export const TrailAreas: CollectionConfig = {
       index: true,
       admin: {
         description:
-          'The heading this area sits under in the sidebar, e.g. "Bend" or "Lookout Mountain". Leave blank to use the built-in mapping.',
+          'The heading this complex sits under in the sidebar — the level above it, e.g. "Bend" or "Cascade Lakes". Leave blank to use the built-in mapping.',
       },
     },
     {

--- a/src/payload/collections/Trails.ts
+++ b/src/payload/collections/Trails.ts
@@ -99,6 +99,15 @@ export const Trails: CollectionConfig = {
       },
     },
     {
+      name: 'organization',
+      type: 'relationship',
+      relationTo: 'organizations',
+      admin: {
+        description:
+          'Who builds and maintains this trail. Manage the list under Map content → Organizations.',
+      },
+    },
+    {
       type: 'row',
       fields: [
         {

--- a/src/payload/collections/Trails.ts
+++ b/src/payload/collections/Trails.ts
@@ -111,13 +111,14 @@ export const Trails: CollectionConfig = {
       type: 'row',
       fields: [
         {
-          name: 'recArea',
-          type: 'text',
+          name: 'area',
+          type: 'relationship',
+          relationTo: 'trail-areas',
           required: true,
-          index: true,
           admin: {
             width: '50%',
-            description: 'Recreation area grouping, e.g. "Stringers Ridge".',
+            description:
+              'Recreation area. Manage the list under Map content → Trail areas.',
           },
         },
         {

--- a/src/payload/collections/Trails.ts
+++ b/src/payload/collections/Trails.ts
@@ -1,5 +1,6 @@
 import type { Access, CollectionConfig } from 'payload';
 import { resolveOsmGeometry } from '@/payload/hooks/resolveOsmGeometry';
+import { activeCityId } from '@/config/map.config';
 import { MAX_WAYS_PER_REQUEST } from '@/payload/osm/overpass';
 
 /**
@@ -34,9 +35,9 @@ export const Trails: CollectionConfig = {
   slug: 'trails',
   admin: {
     useAsTitle: 'displayName',
-    defaultColumns: ['displayName', 'recArea', 'rating', 'distance', 'city'],
+    defaultColumns: ['displayName', 'area', 'rating', 'distance'],
     group: 'Map content',
-    listSearchableFields: ['displayName', 'trailName', 'recArea'],
+    listSearchableFields: ['displayName', 'trailName'],
   },
   // Published trails are public; everything else needs a login.
   access: {
@@ -63,7 +64,7 @@ export const Trails: CollectionConfig = {
           type: 'text',
           required: true,
           admin: {
-            width: '50%',
+            width: '100%',
             description: 'Human-friendly name shown in the sidebar and pane.',
           },
         },
@@ -71,11 +72,18 @@ export const Trails: CollectionConfig = {
           name: 'city',
           type: 'select',
           required: true,
+          defaultValue: activeCityId,
           options: [
             { label: 'Chattanooga', value: 'chattanooga' },
             { label: 'Bend', value: 'bend' },
           ],
-          admin: { width: '50%' },
+          admin: {
+            // Hidden because a deployment serves one city, so asking on every
+            // trail is noise. The column stays: getCityTrails filters on it,
+            // the seeds set it per city, and editor access is scoped by it.
+            // Drop `hidden` to bring the picker back for a multi-city admin.
+            hidden: true,
+          },
         },
       ],
     },
@@ -115,10 +123,10 @@ export const Trails: CollectionConfig = {
           type: 'relationship',
           relationTo: 'trail-areas',
           required: true,
+          label: 'Trail complex',
           admin: {
             width: '50%',
-            description:
-              'Recreation area. Manage the list under Map content → Trail areas.',
+            description: 'Manage the list under Map content → Trail complexes.',
           },
         },
         {

--- a/src/payload/components/ColorField.tsx
+++ b/src/payload/components/ColorField.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * A colour field: native swatch picker beside the hex value.
+ *
+ * Payload has no colour field type, and a bare text input asking for a hex code
+ * is a poor way to choose a brand colour — you can't see it. `<input
+ * type="color">` is built into every browser, needs no dependency, and is
+ * keyboard accessible.
+ *
+ * The text input stays editable so a value can be pasted from a brand guide,
+ * and it is the field's source of truth: the swatch only writes well-formed
+ * hex back into it.
+ */
+import { useField, FieldLabel } from '@payloadcms/ui';
+import type { TextFieldClientProps } from 'payload';
+
+const HEX = /^#[0-9a-f]{6}$/i;
+
+/** The swatch needs a valid 6-digit hex; anything else shows as black. */
+function swatchValue(value: string): string {
+  return HEX.test(value) ? value : '#000000';
+}
+
+export function ColorField({ field, path }: TextFieldClientProps) {
+  const { setValue, showError, value } = useField<string>({ path });
+  const current = value ?? '';
+  const label = typeof field?.label === 'string' ? field.label : path;
+
+  return (
+    <div className="field-type text">
+      <FieldLabel label={label} path={path} required={field?.required} />
+
+      <div style={{ alignItems: 'center', display: 'flex', gap: '0.5rem' }}>
+        <input
+          aria-label={`${label} colour picker`}
+          onChange={(event) => setValue(event.target.value)}
+          style={{
+            background: 'none',
+            border: '1px solid var(--theme-elevation-150)',
+            borderRadius: 'var(--style-radius-s)',
+            cursor: 'pointer',
+            height: 38,
+            padding: 2,
+            width: 48,
+          }}
+          type="color"
+          value={swatchValue(current)}
+        />
+        <input
+          className="field-type__wrap"
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="#c3f44d"
+          spellCheck={false}
+          style={{
+            background: 'var(--theme-input-bg)',
+            border: `1px solid var(--theme-elevation-${showError ? '150' : '150'})`,
+            borderRadius: 'var(--style-radius-s)',
+            color: 'var(--theme-text)',
+            flex: 1,
+            fontFamily: 'var(--font-mono)',
+            padding: '0.5rem 0.75rem',
+          }}
+          type="text"
+          value={current}
+        />
+      </div>
+
+      {field?.admin?.description && (
+        <div className="field-description">
+          {String(field.admin.description)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/payload/globals/Theme.ts
+++ b/src/payload/globals/Theme.ts
@@ -1,0 +1,132 @@
+import type { GlobalConfig } from 'payload';
+
+/**
+ * Admin appearance, editable at `/admin/globals/theme`.
+ *
+ * A global rather than a collection because there is exactly one of it. The
+ * values become CSS custom properties injected by the admin layout — see
+ * `src/payload/read/theme.ts` — so they ride on the same variables
+ * `custom.css` sets, rather than fighting Payload's styles.
+ *
+ * Every field is optional. An unset field falls through to the stylesheet
+ * default, so a half-filled theme is a valid theme and clearing a field is how
+ * you reset it.
+ */
+
+/** Matches the swatch picker's output; also what the CSS variables expect. */
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+function validateHex(value: unknown): string | true {
+  if (!value) {
+    return true;
+  }
+  return HEX.test(String(value))
+    ? true
+    : 'Use a 6-digit hex colour, e.g. #c3f44d.';
+}
+
+export const Theme: GlobalConfig = {
+  slug: 'theme',
+  admin: {
+    description:
+      'How the admin looks. Changes apply on the next page load. Clear a field to fall back to the default.',
+    group: 'Settings',
+  },
+  access: {
+    // Appearance is global — one editor's change is everyone's, so it's an
+    // admin decision. Reading is open because the layout renders it for
+    // whoever is signed in.
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      type: 'collapsible',
+      label: 'Colour',
+      fields: [
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'accentColor',
+              type: 'text',
+              admin: {
+                components: {
+                  Field: '@/payload/components/ColorField#ColorField',
+                },
+                description: 'Focus rings and highlights. Default #c3f44d.',
+                width: '50%',
+              },
+              validate: validateHex,
+            },
+            {
+              name: 'deepColor',
+              type: 'text',
+              admin: {
+                components: {
+                  Field: '@/payload/components/ColorField#ColorField',
+                },
+                description: 'Deep brand colour. Default #1a434e.',
+                width: '50%',
+              },
+              validate: validateHex,
+            },
+          ],
+        },
+        {
+          name: 'neutralTint',
+          type: 'select',
+          options: [
+            { label: 'Cool — leans blue/teal (default)', value: 'cool' },
+            { label: 'Neutral — pure grey', value: 'neutral' },
+            { label: 'Warm — leans brown', value: 'warm' },
+          ],
+          admin: {
+            description:
+              'The cast of the greys everything is built from. Applies to both light and dark mode, because Payload derives dark mode by inverting the same scale.',
+          },
+        },
+      ],
+    },
+    {
+      type: 'collapsible',
+      label: 'Shape & type',
+      fields: [
+        {
+          type: 'row',
+          fields: [
+            {
+              name: 'cornerStyle',
+              type: 'select',
+              options: [
+                { label: 'Sharp — Payload default', value: 'sharp' },
+                { label: 'Soft (default here)', value: 'soft' },
+                { label: 'Round', value: 'round' },
+              ],
+              admin: { width: '50%' },
+            },
+            {
+              name: 'fontFamily',
+              type: 'select',
+              options: [
+                { label: 'Geist — matches the map (default)', value: 'geist' },
+                { label: 'System UI', value: 'system' },
+                { label: 'Serif', value: 'serif' },
+              ],
+              admin: { width: '50%' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'customCss',
+      type: 'textarea',
+      admin: {
+        description:
+          'Escape hatch for anything the fields above do not cover. Injected verbatim into the admin. Admins only — treat it as code.',
+        rows: 6,
+      },
+    },
+  ],
+};

--- a/src/payload/read/theme.test.ts
+++ b/src/payload/read/theme.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// theme.ts is server-only and pulls in the Payload config; the pure CSS builder
+// is what's worth testing, so the server guard and config are stubbed out.
+vi.mock('server-only', () => ({}));
+vi.mock('@payload-config', () => ({ default: {} }));
+
+const { buildThemeCss } = await import('./theme');
+
+describe('buildThemeCss', () => {
+  it('emits nothing when the theme is empty', () => {
+    // An unset theme must fall through to the stylesheet defaults rather than
+    // emitting an empty rule.
+    expect(buildThemeCss({})).toBe('');
+  });
+
+  it('sets the accent colour and the focus ring together', () => {
+    const css = buildThemeCss({ accentColor: '#c3f44d' });
+
+    expect(css).toContain('--brand-accent:#c3f44d');
+    // Payload drives every focus outline through this one variable, so the
+    // accent is only actually visible if this moves with it.
+    expect(css).toContain('--accessibility-outline:2px solid #c3f44d');
+  });
+
+  it('ignores a malformed colour rather than emitting broken CSS', () => {
+    // The field validates, but a value could arrive from a direct API write.
+    expect(buildThemeCss({ accentColor: 'red; }' })).toBe('');
+    expect(buildThemeCss({ accentColor: '#fff' })).toBe('');
+  });
+
+  it('writes the full base ramp for a tint', () => {
+    const css = buildThemeCss({ neutralTint: 'warm' });
+
+    // Both ends of the scale must be present: dark mode is Payload inverting
+    // this same ramp, so a partial one would theme only one mode.
+    expect(css).toContain('--color-base-0:rgb(255,255,255)');
+    expect(css).toContain('--color-base-1000:rgb(0,0,0)');
+    expect(css).toContain('--color-base-500:');
+  });
+
+  it('maps corner styles to all three radii', () => {
+    const css = buildThemeCss({ cornerStyle: 'round' });
+
+    expect(css).toContain('--style-radius-s:10px');
+    expect(css).toContain('--style-radius-m:16px');
+    expect(css).toContain('--style-radius-l:24px');
+  });
+
+  it('keeps a system fallback behind the webfont', () => {
+    // If Geist fails to load, the admin must not fall back to a serif default.
+    expect(buildThemeCss({ fontFamily: 'geist' })).toContain(
+      '--font-body:var(--font-geist-sans), -apple-system',
+    );
+  });
+
+  it('strips angle brackets from custom CSS so it cannot close the style tag', () => {
+    // This is the injection guard: the result is dropped into <style>, and a
+    // stray </style> would turn styling into markup.
+    const css = buildThemeCss({
+      customCss: '</style><script>alert(1)</script>',
+    });
+
+    expect(css).not.toContain('<');
+    expect(css).not.toContain('>');
+    expect(css).toContain('scriptalert(1)/script');
+  });
+
+  it('passes ordinary custom CSS through', () => {
+    expect(buildThemeCss({ customCss: '.nav { opacity: 0.9 }' })).toContain(
+      '.nav { opacity: 0.9 }',
+    );
+  });
+
+  it('combines variables and custom CSS, variables first', () => {
+    const css = buildThemeCss({
+      accentColor: '#123456',
+      customCss: '.x{color:red}',
+    });
+
+    expect(css.indexOf(':root{')).toBeLessThan(css.indexOf('.x{'));
+  });
+});

--- a/src/payload/read/theme.ts
+++ b/src/payload/read/theme.ts
@@ -1,0 +1,179 @@
+import 'server-only';
+
+/**
+ * Turns the saved theme global into CSS the admin layout can inject.
+ *
+ * Everything here resolves to the same custom properties `custom.css` sets, so
+ * a saved theme overrides the stylesheet defaults without touching any of
+ * Payload's own selectors.
+ *
+ * **Never throws.** No database, an unreachable one, or an unset global all
+ * return an empty string, and the stylesheet defaults stand. Nobody should be
+ * locked out of the admin because a theme row could not be read.
+ */
+import { getPayload } from 'payload';
+import config from '@payload-config';
+
+/**
+ * The greys everything is built from. Payload derives dark mode by *inverting*
+ * this scale, so one definition themes both modes — see custom.css.
+ */
+const NEUTRAL_RAMPS = {
+  cool: [
+    '255,255,255',
+    '246,248,249',
+    '238,241,243',
+    '227,232,234',
+    '214,220,223',
+    '184,194,198',
+    '148,161,166',
+    '111,125,131',
+    '86,98,104',
+    '63,74,79',
+    '42,51,56',
+    '31,39,43',
+    '20,26,29',
+    '10,14,16',
+    '0,0,0',
+  ],
+  neutral: [
+    '255,255,255',
+    '245,245,245',
+    '235,235,235',
+    '221,221,221',
+    '208,208,208',
+    '181,181,181',
+    '154,154,154',
+    '128,128,128',
+    '101,101,101',
+    '74,74,74',
+    '47,47,47',
+    '34,34,34',
+    '20,20,20',
+    '7,7,7',
+    '0,0,0',
+  ],
+  warm: [
+    '255,255,255',
+    '249,247,245',
+    '243,240,236',
+    '236,231,225',
+    '224,217,209',
+    '196,187,176',
+    '166,155,143',
+    '133,123,112',
+    '106,97,88',
+    '79,72,65',
+    '52,47,42',
+    '38,34,30',
+    '23,20,18',
+    '12,10,9',
+    '0,0,0',
+  ],
+} as const;
+
+/** Positions in Payload's `--color-base-*` scale, in ramp order. */
+const RAMP_STOPS = [
+  0, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 850, 900, 950, 1000,
+];
+
+const CORNERS = {
+  round: ['10px', '16px', '24px'],
+  sharp: ['3px', '4px', '8px'],
+  soft: ['6px', '10px', '16px'],
+} as const;
+
+const SYSTEM_STACK =
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+
+const FONTS = {
+  geist: `var(--font-geist-sans), ${SYSTEM_STACK}`,
+  serif: `ui-serif, Georgia, Cambria, 'Times New Roman', serif`,
+  system: SYSTEM_STACK,
+} as const;
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+export interface ThemeDoc {
+  accentColor?: null | string;
+  cornerStyle?: keyof typeof CORNERS | null;
+  customCss?: null | string;
+  deepColor?: null | string;
+  fontFamily?: keyof typeof FONTS | null;
+  neutralTint?: keyof typeof NEUTRAL_RAMPS | null;
+}
+
+/**
+ * Strips anything that could close the `<style>` element the result is injected
+ * into. `customCss` is admin-only, but "trusted input" is exactly how injection
+ * bugs get written — a stray `</style>` would turn styling into markup.
+ */
+function sanitizeCss(css: string): string {
+  return css.replace(/[<>]/g, '');
+}
+
+/** Exported for tests; `getThemeCss` is the real entry point. */
+export function buildThemeCss(theme: ThemeDoc): string {
+  return buildCss(theme);
+}
+
+function buildCss(theme: ThemeDoc): string {
+  const declarations: string[] = [];
+
+  if (theme.accentColor && HEX.test(theme.accentColor)) {
+    declarations.push(`--brand-accent:${theme.accentColor}`);
+    declarations.push(`--accessibility-outline:2px solid ${theme.accentColor}`);
+  }
+  if (theme.deepColor && HEX.test(theme.deepColor)) {
+    declarations.push(`--brand-deep:${theme.deepColor}`);
+  }
+
+  const ramp = theme.neutralTint && NEUTRAL_RAMPS[theme.neutralTint];
+  if (ramp) {
+    ramp.forEach((value, index) => {
+      declarations.push(`--color-base-${RAMP_STOPS[index]}:rgb(${value})`);
+    });
+  }
+
+  const corners = theme.cornerStyle && CORNERS[theme.cornerStyle];
+  if (corners) {
+    declarations.push(`--style-radius-s:${corners[0]}`);
+    declarations.push(`--style-radius-m:${corners[1]}`);
+    declarations.push(`--style-radius-l:${corners[2]}`);
+  }
+
+  const font = theme.fontFamily && FONTS[theme.fontFamily];
+  if (font) {
+    declarations.push(`--font-body:${font}`);
+  }
+
+  const root =
+    declarations.length > 0 ? `:root{${declarations.join(';')}}` : '';
+  const custom = theme.customCss ? sanitizeCss(theme.customCss) : '';
+
+  return `${root}${custom}`;
+}
+
+/**
+ * The saved theme as a CSS string, ready to drop into a `<style>` tag.
+ * Empty when there is nothing to override.
+ */
+export async function getThemeCss(): Promise<string> {
+  if (!process.env.DATABASE_URL) {
+    return '';
+  }
+
+  try {
+    const payload = await getPayload({ config });
+    const theme = (await payload.findGlobal({
+      slug: 'theme',
+      depth: 0,
+    })) as ThemeDoc;
+
+    return theme ? buildCss(theme) : '';
+  } catch (error) {
+    // Losing the theme must not lose the admin.
+    console.error('Could not read the admin theme; using defaults.', error);
+    return '';
+  }
+}

--- a/src/payload/read/trails.ts
+++ b/src/payload/read/trails.ts
@@ -58,7 +58,24 @@ function osmIdsFor(value: Trail['osmIds']): number[] | undefined {
   return ids.length > 0 ? ids : undefined;
 }
 
+/**
+ * `area` is a relationship, so at depth 1 it arrives as the related document.
+ * The app has always worked with a plain `recArea` string, so unwrap it here
+ * rather than teach every consumer about the join.
+ */
+function areaOf(trail: Trail): { name: string; region?: string } {
+  const area = trail.area;
+  if (area && typeof area === 'object') {
+    return {
+      name: area.name ?? '',
+      region: area.region ?? undefined,
+    };
+  }
+  return { name: '' };
+}
+
 function toMountainBikeTrail(trail: Trail): MountainBikeTrail {
+  const area = areaOf(trail);
   return {
     color: colorFor(trail),
     defaultBounds: boundsFor(trail.bounds),
@@ -75,7 +92,10 @@ function toMountainBikeTrail(trail: Trail): MountainBikeTrail {
     // `rating` is a select with an explicit 'unrated' option; the app's type
     // uses '' for the same thing.
     rating: trail.rating === 'unrated' ? '' : (trail.rating ?? ''),
-    recArea: trail.recArea ?? '',
+    recArea: area.name,
+    // Set only when the area carries one; the app falls back to its built-in
+    // REGION_MAP otherwise.
+    region: area.region,
     slug: trail.slug ?? undefined,
     trailName: trail.trailName ?? '',
   };
@@ -123,7 +143,8 @@ export async function getCityTrails(city: CityId): Promise<CityTrailData> {
     const payload = await getPayload({ config });
     const result = await payload.find({
       collection: 'trails',
-      depth: 0,
+      // 1 so the `area` relationship resolves to its document rather than an id.
+      depth: 1,
       // One city's curated trails is a few hundred rows; paging them would just
       // add round trips.
       limit: 2000,

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -1,6 +1,7 @@
 import mapboxgl from 'mapbox-gl';
 import type { BikeRoute, MountainBikeTrail } from '@/data/geo_data';
-import { mountainBikeConfig, regionFor, trailMetadata } from '@/data/geo_data';
+import { mountainBikeConfig, trailMetadata } from '@/data/geo_data';
+import { regionOf } from '@/data/trail-region';
 import {
   getMountainBikeTrails,
   onMountainBikeTrailsChange,
@@ -204,8 +205,7 @@ export function getAreaBounds(
   const bounds = new mapboxgl.LngLatBounds();
   let hasCoords = false;
   for (const trail of trails) {
-    if (trail.recArea !== areaName && regionFor(trail.recArea) !== areaName)
-      continue;
+    if (trail.recArea !== areaName && regionOf(trail) !== areaName) continue;
     if (trail.bounds) {
       bounds.extend(trail.bounds);
       hasCoords = true;
@@ -1194,7 +1194,7 @@ export function highlightMtnBikeArea(
   areaName: string,
 ): void {
   const matchedTrails = trails.filter(
-    (t) => t.recArea === areaName || regionFor(t.recArea) === areaName,
+    (t) => t.recArea === areaName || regionOf(t) === areaName,
   );
   if (matchedTrails.length === 0) return;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     setupFiles: ['./tests/vitest-setup.ts'],
     alias: {
       '@': resolve(__dirname, './src'),
+      // Mirrors the tsconfig path. Modules under src/payload import the Payload
+      // config through this specifier; without the alias Vite fails to resolve
+      // it at transform time, before `vi.mock` ever gets a chance to intercept.
+      '@payload-config': resolve(__dirname, './src/payload.config.ts'),
     },
   },
 });


### PR DESCRIPTION
Stacked PR **4 of 7** · base `feat/public-map-from-payload` (#106) · stack #107

Turns the free-text and hardcoded parts of a trail into curated lists, and makes the admin's appearance editable.

- **Recreation areas become a dropdown** (`trail-areas`). This was free text, so a typo silently created a new sidebar grouping that looked real. As a collection the options are picked, not typed, and renaming one updates every trail at once.
- **`region` moves out of code.** The sidebar groups areas into regions, and that mapping was a hardcoded `REGION_MAP` per city — adding an area meant editing TypeScript. It's a field on the area now. Group with `regionOf(trail)`, never `regionFor(recArea)`: the former prefers the stored value and falls back to the built-in map, the latter can't see the database.
- **Trail organizations** — the clubs and agencies that maintain trails.
- **An editable admin theme** (`Theme` global), injected as CSS custom properties by the admin layout.

### Two things that matter

**Theme through CSS variables, never Payload's selectors.** Class names like `.btn__content` are internals that move between releases. `--theme-elevation-*` resolves to a `--color-base-*` scale that dark mode *inverts*, so retinting that ramp themes both modes at once.

**A real bug fixed here** (`1dad8ba`): the sidebar's region → area grouping ran at module scope, so it captured the checked-in fallback data at import time and never saw a database row. It runs during render now. This is the same trap `getMountainBikeTrails()` exists to prevent.

"Trail complex" is an admin **label** only — the slug and table stay `trail-areas` and the app field stays `recArea`, so no migration.
