### PR TITLE
feat: crowdsourced trail conditions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,12 @@ DATABASE_SSL=disable
 # random string. NEVER commit the real value.
 #   openssl rand -base64 32
 PAYLOAD_SECRET=
+
+# Optional. Salts the one-way hash of a condition reporter's IP address, which
+# is what rate-limits the public report form. Leave it unset and PAYLOAD_SECRET
+# is used, which is why this is not something you have to set — but setting it
+# lets you rotate the hashes (invalidating every rate-limit bucket) without
+# signing everyone out of the admin.
+#
+# The IP address itself is never stored, only this hash of it.
+# CONDITION_REPORT_SALT=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -633,6 +633,15 @@ else.
   `CONDITION_FRESH_DAYS` (14) and stays in history. A stale condition is worse
   than none: a green "Dry" pill from October is wrong in March in a way that
   looks authoritative. `ConditionBadge` owns that rule for both surfaces.
+- **A closure is the exception, and never expires.** A condition type flagged
+  `marksClosed` (seeded on "Closed") draws the trail as a **red dashed overlay**
+  above its normal line, and its badge holds until someone reports something
+  else — a trail does not reopen because nobody rode it for a fortnight. Ask
+  `isConditionCurrent`, not `isConditionFresh`, on anything user-facing. This is
+  also why `getConditionSummary` has **no date floor**: a window would quietly
+  reopen a trail shut last season. Which conditions close is **data** — nothing
+  matches on the value `'closed'`. The "closed to reports" switches are
+  moderation and deliberately do *not* mark the map.
 - **`ElevationProfile` no longer requires a chart to open.** Its guard is now
   `hasProfile || hasConditions`, with the chart, y-axis, stats and GPX button
   conditional — otherwise conditions would be invisible on exactly the trails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -588,8 +588,69 @@ Things to know before touching it:
 - **Generated, lint-excluded**: `src/payload-types.ts`, `src/migrations/`,
   `src/app/(payload)/admin/importMap.js`.
 
+### Crowdsourced Trail Conditions
+
+Anyone can report what a trail was like — no account — from the selected-trail
+pane. The options come from a curated vocabulary. Full guide:
+[`docs/guides/trail-conditions.md`](docs/guides/trail-conditions.md).
+
+Two collections: `trail-condition-types` (the dropdown, nav group **Lists**, the
+same shape as `trail-ratings`) and `trail-conditions` (the reports, its own nav
+group **Conditions**). A report is a condition and an observed date, nothing
+else.
+
+- **This is the only public write path in the app, and it has exactly one door.**
+  `TrailConditions`'s access rules are **admin-only on purpose** — that is what
+  keeps Payload's own `/api/trail-conditions` shut. The public write goes
+  through `POST /api/map/conditions`, which validates first and then uses the
+  Local API (which bypasses access control by design). **Relaxing `create` on
+  the collection opens a second, unguarded door.**
+- **Anti-abuse is a honeypot plus a per-IP-hash rate limit**, both in
+  `src/payload/conditions/guard.ts` — pure, no Payload import, so it is testable
+  without a database. A tripped honeypot gets a **fake `200`**, never an error:
+  an error tells the bot which field is the trap. No captcha and no new service,
+  per ADR-0001 C3. `guard.ts` is where a captcha would go if one is ever needed.
+- **The IP is never stored** — only a salted, truncated one-way hash, in
+  `reporterHash`, so a spree can be found and removed together.
+  `CONDITION_REPORT_SALT` is optional and falls back to `PAYLOAD_SECRET`.
+- **Reports are live immediately; `hidden` is the moderation lever.** No drafts
+  on this collection — it is append-only data, and a versions table would double
+  the writes to express one boolean.
+- **Three switches close reporting, and any one is enough**: the
+  `condition-reporting` global (site-wide, mainly so a fork can ship the trail
+  data without a public form), and a `conditionReportsClosed` checkbox + note on
+  a trail and on a trail complex. Notes resolve most-specific-first via
+  `resolveLockMessage`. **Closing stops new reports; it never hides old ones** —
+  on a shut trail, what it was like when someone last rode it is the point.
+  Ask `lockFor(summary, slug)` rather than reading `locked`/`reporting`
+  separately, or the precedence gets re-derived and drifts.
+- **The hidden button is a courtesy; `submitConditionReport` is the gate.** It
+  re-checks all three switches and returns **403** with the same message. The
+  flag is named for the exception (`conditionReportsClosed`, default false) so
+  `ADD COLUMN ... DEFAULT false` needed no backfill and the lookup isn't
+  `equals: true` against a column of nulls.
+- **Staleness is deliberate.** A report stops driving the badge after
+  `CONDITION_FRESH_DAYS` (14) and stays in history. A stale condition is worse
+  than none: a green "Dry" pill from October is wrong in March in a way that
+  looks authoritative. `ConditionBadge` owns that rule for both surfaces.
+- **`ElevationProfile` no longer requires a chart to open.** Its guard is now
+  `hasProfile || hasConditions`, with the chart, y-axis, stats and GPX button
+  conditional — otherwise conditions would be invisible on exactly the trails
+  nobody has curated yet. The gate also tests that the vocabulary loaded, so the
+  pane never opens on an empty strip with no database.
+- **Conditions key on the trail's `slug`, never its name** — two complexes can
+  both have a "Larry". `curatedSlug()` in the pane returns `null` for an OSM way,
+  a route or a recorded ride; don't confuse it with `profileSlug()` beside it,
+  which deliberately invents a slug for an unrecognised name.
+- **`Trails` has a `beforeDelete` hook that clears a trail's reports.**
+  `trail_conditions.trail_id` is NOT NULL with an ON DELETE SET NULL FK — Payload
+  generates that pair, and together they make Postgres *refuse* to delete a trail
+  anyone has reported on. Reads also skip a report whose trail is null.
+
 ## Configuration & Secrets
 
 - Mapbox credentials belong in `.env.local`; see `.env.example` for required keys.
 - Never commit secrets or `.env.local` to version control.
 - `DATABASE_URL` and `PAYLOAD_SECRET` are only needed for the content backend.
+- `CONDITION_REPORT_SALT` is optional; it salts the condition-reporter hash and
+  falls back to `PAYLOAD_SECRET`.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Open Bike Map is a fork-and-edit, not a rewrite. Everything a community controls
 
 - **`src/config/site.config.ts`** — branding (name, description, colors, PWA identity).
 - **`src/config/map.config.ts`** — geography (Mapbox style, default view, GBFS feed, region).
-- **`src/data/*`** — routes, trails, shops, and points of interest as plain typed arrays. No database, no CMS.
+- **`src/data/*`** — routes, trails, shops, and points of interest as plain typed arrays. The map runs on these alone, with no database.
 - **`public/*`** — logos, icons, splash screens.
+
+Optionally, add Postgres and you also get **`/admin`** — a CMS where someone without a GitHub account can curate trails, and where riders' condition reports land.
 
 The full step-by-step is in **[docs/DEPLOYING.md](docs/DEPLOYING.md)**; the data-file contract is in **[docs/DATA.md](docs/DATA.md)**.
 

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,8 +1,12 @@
 # Data files
 
 All content shown on the map lives in `src/data/` as plain, typed TypeScript
-arrays — no database, no CMS, no admin panel. To change what a deployment
-shows, edit an array and ship a PR.
+arrays. To change what a deployment shows, edit an array and ship a PR.
+
+These are also the fallback the map uses when no database is configured, and the
+source the seeds import from. Stand up the optional CMS
+([DEPLOYING.md](DEPLOYING.md#10-content-backend-database-and-admin-optional))
+and trails come from there instead, with these left as the safety net.
 
 Each file exports a typed array; the `interface` at the top of the file is the
 contract. `icon` fields are Font Awesome `IconDefinition` values imported from

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -11,6 +11,8 @@ end-to-end checklist. A condensed version is at the [bottom](#checklist).
   vector tilesets, terrain)
 - **Python 3.10+** — only if you have mountain bike trails to process
 - A host for the build — **Vercel** works with zero config
+- A **Postgres** database — only if you want the admin (step 10). The public map
+  runs without one.
 
 ## 1. Fork and run locally
 
@@ -130,7 +132,77 @@ Replace with your own:
 - **iOS splash screens** — `public/splash/*`
 - **README screenshots** — `screenshot-splash.png`, `screenshot-route.png`
 
-## 10. Deploy
+## 10. Content backend — database and admin (optional)
+
+Skip this and the map still works: it renders from the checked-in data in
+`src/data/`. Add it and you get `/admin`, where someone without a GitHub account
+can edit trails, and where riders' condition reports land.
+
+Any Postgres works — Neon, Supabase, RDS, your own. No extensions needed.
+
+### Environment variables
+
+Set these wherever you host, **and for every environment you want the admin in**
+— a variable scoped to Development only does nothing for a deployed site, which
+is the easiest mistake to make here.
+
+| Variable | |
+|---|---|
+| `DATABASE_URL` | Postgres connection string |
+| `PAYLOAD_SECRET` | Signs admin sessions. Generate your own: `openssl rand -base64 32` |
+| `DATABASE_SSL` | Set to `disable` for a local database with no TLS |
+
+### Run the migrations
+
+**Migrations do not run on deploy.** The build is `next build` and nothing more,
+and `push` is off — the schema only ever changes through committed migrations
+that you apply yourself. A fresh database has no tables until you do this:
+
+```bash
+DATABASE_URL='<your deployed database>' pnpm db:migrate
+DATABASE_URL='<your deployed database>' pnpm db:seed:bend   # optional starter data
+```
+
+You run this **once when you set the database up, and again after any deploy
+that adds a migration** — otherwise the new code meets an old schema. Check
+before deploying:
+
+```bash
+DATABASE_URL='<your deployed database>' pnpm payload migrate:status
+```
+
+On Vercel, `vercel env pull` gets you the connection string without copying it
+by hand.
+
+> **Neon and other pooled providers:** run migrations against the **unpooled**
+> connection (`DATABASE_URL_UNPOOLED`), not the pooler. PgBouncer in transaction
+> mode does not reliably handle the DDL a migration runs. The app itself should
+> keep using the pooled URL.
+
+Automating this into the build command is possible but not recommended: it makes
+every deploy a schema change against live data, which is exactly what committed
+migrations exist to avoid.
+
+### First sign-in
+
+Visit `/admin`. With no users yet it offers a create-first-user form; after that
+the route is closed to anyone signed out.
+
+### Elevation charts
+
+Trails seeded from the checked-in data have distance and climb figures but no
+chart — the seed skips the measuring hook on purpose, so a few hundred rows
+don't fire a few hundred Overpass requests. Fill them in once:
+
+```bash
+DATABASE_URL='<your deployed database>' pnpm backfill:elevation
+```
+
+It samples terrain only, never Overpass, so it is safe to run over everything
+and safe to re-run. Expect the summary numbers to shift slightly — it remeasures
+them with the same maths the chart uses, so the two can't disagree.
+
+## 11. Deploy
 
 ```bash
 pnpm build      # verify the production build locally
@@ -138,7 +210,14 @@ pnpm build      # verify the production build locally
 
 On **Vercel**: import the repo, and add `NEXT_PUBLIC_MAPBOX_TOKEN` under
 Settings → Environment Variables for **Production, Preview, and Development**.
-Any Node host works — `pnpm build` then `pnpm start`.
+Add `DATABASE_URL` and `PAYLOAD_SECRET` too if you did step 10 — and remember
+that `NEXT_PUBLIC_*` values are baked in at build time, so changing one needs a
+redeploy, not just a save. Any Node host works — `pnpm build` then `pnpm start`.
+
+Every push to any branch gets its own preview deployment. If a deploy includes a
+new migration, apply it before or immediately after the deploy — the app
+tolerates an unreachable database (the map falls back to the checked-in data),
+but not a schema that is behind the code.
 
 ## Checklist
 
@@ -151,3 +230,6 @@ Any Node host works — `pnpm build` then `pnpm start`.
 - [ ] `public/terrain/` DEM tiles regenerated or removed (ride-recording elevation)
 - [ ] `public/` brand assets replaced
 - [ ] `pnpm build` passes; host env var set
+- [ ] *(if using the admin)* `DATABASE_URL` and `PAYLOAD_SECRET` set on the host
+- [ ] *(if using the admin)* `pnpm db:migrate` run against the deployed database
+- [ ] *(if using the admin)* first user created at `/admin`

--- a/docs/guides/trail-conditions.md
+++ b/docs/guides/trail-conditions.md
@@ -1,0 +1,275 @@
+# Trail conditions
+
+The map says how hard a trail is and how much it climbs. Neither answers the
+question a rider actually has on a Saturday morning: **is it rideable today?**
+
+That answer changes daily, it comes from whoever rode it last, and no trail org
+has the staff to keep it current by hand. So anyone can file a report — no
+account, no email — from the trail they are already looking at. What they can
+report is curated in the admin.
+
+---
+
+## What a report is
+
+A **condition** and a **date**. That is the whole thing.
+
+Deliberately. Each of the obvious additions was considered and left out:
+
+- **A note** needs moderating, and a free-text field on an anonymous form is the
+  single most abused thing on the internet.
+- **A photo** needs blob storage, which every fork would have to configure — and
+  image moderation, which is a different project.
+- **A name** nobody verifies is decoration that reads like attribution.
+
+The date is when the trail was *ridden*, not when the form was submitted, so
+someone can log Saturday's ride on Sunday morning. It is bounded: no more than
+30 days back, no more than a day forward.
+
+## Where it shows
+
+- **A pill on each sidebar trail row**, so you can scan a whole complex at once.
+- **The selected-trail pane**, with the age, a history disclosure, and the
+  button that opens the form.
+
+Both go through `ConditionBadge`, which is also where the staleness rule lives.
+
+### Staleness is a feature
+
+A report stops driving the badge after `CONDITION_FRESH_DAYS` (14). It stays in
+the trail's history; it just stops being presented as the current answer.
+
+This matters more than it sounds. A stale condition is worse than no condition:
+a green "Dry" pill left over from October is not merely unhelpful in March, it
+is *wrong in a way that looks authoritative*, and someone drives to a trailhead
+on it. When the newest report has aged out, the pane says "last reported 3
+months ago — dry" instead, which is information rather than a claim.
+
+## The collections
+
+| | slug | group | what it is |
+|---|---|---|---|
+| Trail conditions | `trail-condition-types` | Lists | the dropdown's options |
+| Condition reports | `trail-conditions` | Conditions | the reports themselves |
+
+`trail-condition-types` is the same curated-vocabulary pattern as trail ratings
+and kinds — name, stable `value`, colour, sort order — because conditions are
+*local*. "Dusty / loose" is the interesting distinction in Bend in August and
+meaningless in a Tennessee spring; "Snow / ice" is the reverse.
+
+Two things follow from it being data:
+
+- **Colour comes off the row**, never off the report. Recolouring a condition in
+  the admin repaints every badge that ever used it.
+- **`value` is the stable key.** `name` is a label a curator may reword at any
+  time. Never match on it.
+
+Retire an option by unticking **Offer this on the report form** rather than
+deleting it — Payload blocks deleting a row a past report still points at, and
+that block is correct.
+
+## Closing a trail to new reports
+
+Three switches, and **any one of them being off is enough**:
+
+| Where | What it closes |
+|---|---|
+| Settings → **Condition reporting** | the whole map |
+| A **trail complex** → Condition reports | every trail in it |
+| A **trail** → Condition reports | just that one |
+
+Each carries an optional **note** — the sentence a rider sees where the "Report"
+button was ("Closed for logging until 1 May"). The most specific one wins: trail,
+then complex, then site-wide, then a plain fallback. Ticking the box and leaving
+the note blank means "no comment", not "show an empty line".
+
+The site-wide switch exists mainly **for a fork**. This repo is meant to be stood
+up by any trail org, and some will want the curated trail data without a public
+form on it; without this their only option is not deploying the feature. It is
+also the fastest lever if the form is ever abused at scale.
+
+### What closing does *not* do
+
+**It stops new reports. It does not hide old ones.** The badge, the age and the
+history all stay exactly as they were. Two reasons:
+
+- On a closed trail, knowing it is closed — and what it was like when someone
+  last rode it — is the most useful thing on the page. That is the whole reason
+  you'd close it.
+- Data gathered while the form was open does not stop being true because the
+  form closed. Hiding it would be unsaying it.
+
+### The button is a courtesy; the server is the gate
+
+Hiding the button is cosmetic — a closed trail is one `curl` away from a report
+otherwise. `submitConditionReport` re-checks all three switches and answers
+**403** with the same message the button would have shown. It resolves precedence
+through the same `resolveLockMessage`, so the two can't give different reasons.
+
+Why 403 rather than 404 or 429: the trail is real and the rider has done nothing
+wrong. Someone decided this one isn't taking reports, and the message says why.
+
+### Why the flag is named for the exception
+
+`conditionReportsClosed` defaults to `false` rather than a positive
+`acceptConditionReports` defaulting to `true`. That is what let the migration be
+purely additive: `ADD COLUMN ... DEFAULT false` leaves every trail that already
+existed open, which is what it was a moment ago. The positive name would have
+needed a data migration to say the same thing, and would have made the lookup
+`equals: true` against a column full of nulls.
+
+## Moderation
+
+Reports are **live the moment they land**. An approval queue would make the
+whole feature worthless: by the time someone got to it, the answer would be
+about last week.
+
+The lever is the `hidden` checkbox on a report. Tick it and the report leaves
+the badge, the history and the API within about 30 seconds (the GET's cache
+window). The row stays, so a pattern of abuse is still visible in the admin.
+
+Sorting by **Reporter** groups everything from one source, which is how you undo
+a spree in one pass.
+
+There are **no drafts on this collection**, unlike Trails. A report is
+append-only data written once and never edited; a `_trail_conditions_v` shadow
+table would double the write volume to express one boolean.
+
+---
+
+## How an anonymous write stays safe
+
+This is the only public write path in the application, so it is worth being
+precise about.
+
+### One door
+
+`TrailConditions`'s access rules are **admin-only, on purpose** — they are not
+an oversight left over from the signed-in collections. Payload mounts its own
+REST API at `/api/trail-conditions`, and those rules are what keep it shut:
+
+```
+$ curl -X POST http://localhost:3000/api/trail-conditions -d '...'
+403
+```
+
+The public write goes through `POST /api/map/conditions`, which validates the
+submission itself and *then* calls Payload's Local API — which bypasses access
+control by design. One door, and it is the guarded one.
+
+**Relaxing `create` on the collection would quietly open a second, unguarded
+door.** Don't.
+
+### What guards it
+
+`src/payload/conditions/guard.ts`, kept pure (no Payload import, no
+`server-only`) so every rule in it is unit-testable without a database.
+
+1. **A honeypot** — a hidden `website` field, positioned off-screen rather than
+   `display: none`, which the better bots know to skip. A filled one gets a
+   plain `200` with a success-shaped body and **no write**. Answering with an
+   error would tell it which field is the trap, which is exactly the feedback
+   needed to get past it next time.
+2. **A rate limit**, keyed to a salted SHA-256 hash of the submitter's address:
+   5 reports an hour across all trails, and one per trail per 30 minutes. The
+   two stop different things — the hourly cap stops one person rewriting the map
+   in an afternoon, the cooldown stops one opinion being repeated until it looks
+   like a consensus.
+3. **Validation** — the trail must be published in this city, the condition must
+   be an active row, the date must be in the window.
+
+### The threat model, stated plainly
+
+This is a regional trail map. The realistic abuse is a bored local marking every
+trail "Closed", or a scraper spraying a form it found. The two measures above
+cover both, cost nothing, and add **no configuration a forker has to do** — which
+was the requirement (ADR-0001, criterion C3).
+
+Neither is a wall. `x-forwarded-for` is a client-settable header, trustworthy
+only because something in front of the app rewrites it (true on Vercel and
+behind a normal reverse proxy, false if the app is exposed directly). If this
+map ever attracts a determined attacker, the answer is a captcha, and
+`guard.ts` is the module it goes in.
+
+### Privacy
+
+**The IP address is never stored.** What lands in `reporterHash` is a salted,
+truncated one-way hash — enough to count one person's reports and to find the
+rest of them once one turns out to be abuse, and not enough to work backwards
+to who they are.
+
+Set `CONDITION_REPORT_SALT` to rotate the hashes (invalidating every rate-limit
+bucket) without signing anyone out of the admin. Unset, it falls back to
+`PAYLOAD_SECRET`, which is why it is optional.
+
+---
+
+## The pane opens for conditions now
+
+`ElevationProfile` used to render `null` unless the trail had a chart, which was
+fine while a chart was the only thing in it.
+
+It now opens for **a chart or conditions**, with the chart, the y-axis, the
+distance/climbing stats and the GPX button all conditional. Without that,
+conditions would have been invisible on exactly the trails nobody has curated
+yet — every Chattanooga trail, whose geometry still lives in a Mapbox tileset,
+and any trail whose ways Overpass could not resolve.
+
+The gate also tests that the vocabulary loaded: with no database there are no
+options, and the pane must not open on an empty strip.
+
+Conditions attach to a **curated trail**, so `curatedSlug()` returns `null` for
+an OSM way picked off the nationwide layer, a bike route, or a recorded ride —
+none of which have a row to hang reports on. It is stricter than `profileSlug()`
+next to it, which invents a slug for an unrecognised name so the elevation fetch
+has something to try.
+
+---
+
+## API
+
+```
+GET  /api/map/conditions?city=bend          → { options, latest }
+POST /api/map/conditions?city=bend          → file a report
+GET  /api/map/conditions/<slug>?city=bend   → { slug, reports }
+```
+
+Under `/api/map` for the usual reason: Payload owns `/api/<collection>`.
+
+`latest` is keyed by **trail slug** — not name. Two complexes can and do have a
+"Larry". So is `locked`, which lists only the closed trails with their resolved
+message; `reporting: { enabled, message }` carries the site-wide switch so a
+global closure needn't name every slug. `lockFor(summary, slug)` combines the
+two — use it rather than reading either field directly, or the precedence gets
+re-derived somewhere and drifts.
+
+The GET caches for 30 seconds, much shorter than the trails route's hour,
+because conditions are the one thing on this map that is supposed to change
+during the day. The POST returns the report it just wrote so the client can show
+it immediately rather than waiting the cache out — the rider who just filed it
+is the one person guaranteed to be looking.
+
+The GET has **no 503 branch**, unlike the trails route: `getConditionSummary`
+answers empty on an unreachable database, and a map with no badges is the map as
+it was last week. An error would have the client retrying over something
+optional.
+
+---
+
+## Things that will bite you
+
+- **`Trails` has a `beforeDelete` hook that clears a trail's reports first.**
+  `trail_conditions.trail_id` is `NOT NULL` with an `ON DELETE SET NULL` foreign
+  key — Payload generates that pair for a required relationship, and together
+  they mean Postgres *refuses* to delete a trail anyone has ever reported on. If
+  you see a not-null violation on `trail_id`, that hook is what stopped working.
+- **Every read skips a report whose trail is null**, for the same reason. It
+  should be unreachable, but a direct SQL delete would leave one, and it must
+  not become a badge on no trail.
+- **The provider layers locally-filed reports over every server response.** A
+  refresh right after a submission can race the 30-second cache and come back
+  without the report the rider just filed; watching your own report vanish reads
+  as the submission having failed.
+- **`conditionAgeLabel` switches to months at 60 days, not 30**, so it never has
+  to say "1 months ago". The earlier version had a `'a month ago'` branch that
+  was unreachable — the weeks branch ran to 62 days.

--- a/docs/guides/trail-conditions.md
+++ b/docs/guides/trail-conditions.md
@@ -34,6 +34,37 @@ someone can log Saturday's ride on Sunday morning. It is bounded: no more than
 
 Both go through `ConditionBadge`, which is also where the staleness rule lives.
 
+## Closed trails show on the map
+
+A trail whose **newest report** carries a condition flagged "Mark the trail as
+closed on the map" is drawn as a **red dashed line over its normal one**.
+
+An overlay rather than a recolour: the green/blue/black rating colours are what
+the legend and the sidebar swatches mean, and turning a closed trail red would
+leave the two disagreeing. The dash is what carries the meaning, so it still
+reads without relying on colour at all.
+
+**Which conditions close a trail is data, not code.** `marksClosed` is a
+checkbox on the condition type — seeded on "Closed", and a curator can tick it on
+"Snow / ice" too. Nothing in the app matches on the value `'closed'`.
+
+**A closure does not expire.** Everything else fades after
+`CONDITION_FRESH_DAYS`; a closure holds until somebody reports the trail as
+something else. A closure is a state, not an observation — a trail does not
+quietly reopen because nobody has ridden it in a fortnight, and expiring one
+would take a barrier off the map on a timer. `isConditionCurrent` is where that
+rule lives; ask it rather than `isConditionFresh` on anything user-facing.
+
+That is also why `getConditionSummary` has **no date floor** on its query. A
+window would silently reopen a trail shut last season. The row limit is the
+bound instead: newest-first means the newest report per trail is in the result
+while total non-hidden reports stay under it. Past that, the answer is a
+current-condition column on the trail.
+
+**The "closed to reports" switches do not do this.** Those are moderation — an
+admin muting a trail that is attracting nonsense should not paint it closed for
+riders. Only a condition marks the map.
+
 ### Staleness is a feature
 
 A report stops driving the badge after `CONDITION_FRESH_DAYS` (14). It stays in

--- a/scripts/seed/shared.ts
+++ b/scripts/seed/shared.ts
@@ -16,6 +16,7 @@ import {
   type MountainBikeTrail,
   slugForTrail,
 } from '../../src/data/mountain-bike-trails';
+import { DEFAULT_CONDITIONS } from '../../src/data/condition-vocabulary';
 import {
   DEFAULT_KIND_VALUE,
   DEFAULT_KINDS,
@@ -94,6 +95,20 @@ export async function loadVocabulary(payload: Payload): Promise<Vocabulary> {
     );
   }
 
+  // Conditions are seeded here too, though no trail points at one, for the same
+  // reason ratings are: the relationship on a *report* is required, so a
+  // database with no condition rows is one nobody can file a report against.
+  // Nothing is returned — the seeds never need the ids.
+  for (const seed of DEFAULT_CONDITIONS) {
+    const id = await findByValue(payload, 'trail-condition-types', seed.value);
+    if (id === undefined) {
+      await payload.create({
+        collection: 'trail-condition-types',
+        data: { ...seed, active: true },
+      });
+    }
+  }
+
   return { kinds, ratings };
 }
 
@@ -106,7 +121,7 @@ export async function loadVocabulary(payload: Payload): Promise<Vocabulary> {
  */
 async function findByValue(
   payload: Payload,
-  collection: 'trail-kinds' | 'trail-ratings',
+  collection: 'trail-condition-types' | 'trail-kinds' | 'trail-ratings',
   value: string,
 ): Promise<number | undefined> {
   const existing = await payload.find({

--- a/scripts/seed/shared.ts
+++ b/scripts/seed/shared.ts
@@ -104,7 +104,7 @@ export async function loadVocabulary(payload: Payload): Promise<Vocabulary> {
     if (id === undefined) {
       await payload.create({
         collection: 'trail-condition-types',
-        data: { ...seed, active: true },
+        data: { ...seed, active: true, marksClosed: seed.marksClosed === true },
       });
     }
   }

--- a/src/app/(frontend)/HomeClient.tsx
+++ b/src/app/(frontend)/HomeClient.tsx
@@ -3,7 +3,9 @@
 import type { ReactElement } from 'react';
 import dynamic from 'next/dynamic';
 import React, { useEffect } from 'react';
+import { ConditionReportModal } from '@/components/ConditionReportModal';
 import { PwaInstallPrompt } from '@/components/PwaInstallPrompt';
+import { TrailConditionsProvider } from '@/components/TrailConditionsProvider';
 import { WelcomeModal } from '@/components/WelcomeModal';
 import { bikeRoutes } from '@/data/geo_data';
 import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
@@ -84,7 +86,13 @@ export default function HomeClient({
 
   return (
     <main className="overflow-hidden fixed inset-0 m-0 p-0">
-      <BikeMap />
+      {/* Wraps the map so the sidebar's badges and the report form share one
+          copy of the conditions, and sits out here rather than inside BikeMap
+          because the form is a sibling of the map, like WelcomeModal. */}
+      <TrailConditionsProvider>
+        <BikeMap />
+        <ConditionReportModal />
+      </TrailConditionsProvider>
       <PwaInstallPrompt />
       <WelcomeModal />
     </main>

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,3 +1,4 @@
+import { TrailConditionLog as TrailConditionLog_99c3b61efc8df4edfdf8681317d13e83 } from '@/payload/components/TrailConditionLog'
 import { TrailDisplayNameField as TrailDisplayNameField_e98aef2becee800628e4b2016d1a744a } from '@/payload/components/DerivedTextField'
 import { TrailSlugField as TrailSlugField_e98aef2becee800628e4b2016d1a744a } from '@/payload/components/DerivedTextField'
 import { TrailMapEditor as TrailMapEditor_3ac3e0a5a2d5f3d2cb9858c36a6e6bef } from '@/payload/components/TrailMapEditor'
@@ -10,6 +11,7 @@ import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 
 /** @type import('payload').ImportMap */
 export const importMap = {
+  "@/payload/components/TrailConditionLog#TrailConditionLog": TrailConditionLog_99c3b61efc8df4edfdf8681317d13e83,
   "@/payload/components/DerivedTextField#TrailDisplayNameField": TrailDisplayNameField_e98aef2becee800628e4b2016d1a744a,
   "@/payload/components/DerivedTextField#TrailSlugField": TrailSlugField_e98aef2becee800628e4b2016d1a744a,
   "@/payload/components/TrailMapEditor#TrailMapEditor": TrailMapEditor_3ac3e0a5a2d5f3d2cb9858c36a6e6bef,

--- a/src/app/api/map/conditions/[slug]/route.ts
+++ b/src/app/api/map/conditions/[slug]/route.ts
@@ -1,0 +1,49 @@
+/**
+ * One trail's condition history, newest first.
+ *
+ *   /api/map/conditions/pointe-break?city=bend
+ *
+ * A 404 means the trail is unknown; an empty list means nobody has reported on
+ * it. The pane needs to tell those apart — the first is a bug, the second is an
+ * invitation.
+ */
+import { NextResponse } from 'next/server';
+import type { CityId } from '@/data/cities/types';
+import { getTrailConditionHistory } from '@/payload/read/conditions';
+
+const CITY_IDS: CityId[] = ['bend', 'chattanooga'];
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const city = new URL(request.url).searchParams.get('city') as CityId | null;
+
+  if (!city || !CITY_IDS.includes(city)) {
+    return NextResponse.json(
+      { error: `city must be one of: ${CITY_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  const reports = await getTrailConditionHistory(slug, city);
+
+  if (reports === null) {
+    return NextResponse.json(
+      { error: `No trail with the slug "${slug}".` },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    { reports, slug },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=30, stale-while-revalidate=300',
+      },
+    },
+  );
+}

--- a/src/app/api/map/conditions/route.ts
+++ b/src/app/api/map/conditions/route.ts
@@ -1,0 +1,120 @@
+/**
+ * Trail conditions: the current picture, and the way to add to it.
+ *
+ *   GET  /api/map/conditions?city=bend   → { options, latest, locked, reporting }
+ *   POST /api/map/conditions             → file a report
+ *
+ * Under /api/map because Payload owns /api/<collection>, and
+ * /api/trail-conditions is deliberately shut. **This is the only public write
+ * path in the app**; everything it lets through, it has checked first.
+ *
+ * Both verbs share a file so the client has one URL — hence the GET's caching is
+ * a header, not `export const revalidate`, which applies to the whole segment.
+ */
+import { NextResponse } from 'next/server';
+import type { CityId } from '@/data/cities/types';
+import {
+  clientAddress,
+  hashReporter,
+  isHoneypotTripped,
+  parseIdentifier,
+  parseObservedAt,
+  reporterSalt,
+  type ReportBody,
+} from '@/payload/conditions/guard';
+import { submitConditionReport } from '@/payload/conditions/submit';
+import { getConditionSummary } from '@/payload/read/conditions';
+
+const CITY_IDS: CityId[] = ['bend', 'chattanooga'];
+
+export const dynamic = 'force-dynamic';
+
+function cityFrom(request: Request): CityId | null {
+  const city = new URL(request.url).searchParams.get('city') as CityId | null;
+  return city && CITY_IDS.includes(city) ? city : null;
+}
+
+export async function GET(request: Request) {
+  const city = cityFrom(request);
+
+  if (!city) {
+    return NextResponse.json(
+      { error: `city must be one of: ${CITY_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  // No 503 branch, unlike the trails route: `getConditionSummary` answers empty
+  // on an unreachable database, and a map with no badges beats a client
+  // retrying over something optional.
+  const summary = await getConditionSummary(city);
+
+  return NextResponse.json(summary, {
+    headers: {
+      // Shorter than the trails route's hour: conditions are meant to change
+      // during the day.
+      'Cache-Control': 'public, max-age=30, stale-while-revalidate=300',
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  const city = cityFrom(request);
+
+  if (!city) {
+    return NextResponse.json(
+      { error: `city must be one of: ${CITY_IDS.join(', ')}` },
+      { status: 400 },
+    );
+  }
+
+  let body: ReportBody;
+  try {
+    body = (await request.json()) as ReportBody;
+  } catch {
+    return NextResponse.json({ error: 'Expected JSON.' }, { status: 400 });
+  }
+
+  // Answered with a lie: telling it the field was a trap only teaches it which
+  // one to leave alone. It gets the success it expected, and nothing is written.
+  if (isHoneypotTripped(body)) {
+    return NextResponse.json({ ok: true });
+  }
+
+  const slug = parseIdentifier(body.slug);
+  const condition = parseIdentifier(body.condition);
+  if (!slug || !condition) {
+    return NextResponse.json(
+      { error: 'A trail and a condition are required.' },
+      { status: 400 },
+    );
+  }
+
+  const observedAt = parseObservedAt(body.observedAt);
+  if (!observedAt.ok) {
+    return NextResponse.json({ error: observedAt.error }, { status: 400 });
+  }
+
+  const result = await submitConditionReport({
+    city,
+    condition,
+    observedAt: observedAt.value,
+    reporterHash: hashReporter(clientAddress(request.headers), reporterSalt()),
+    slug,
+  });
+
+  if (!result.ok) {
+    // 403 for a closed trail: it's real and the rider has done nothing wrong.
+    const status = {
+      locked: 403,
+      'not-found': 404,
+      'rate-limited': 429,
+      unavailable: 503,
+    }[result.reason];
+    return NextResponse.json({ error: result.message }, { status });
+  }
+
+  // The report comes back so the client can show it without waiting out the
+  // GET's cache — the rider who filed it is the one person certain to be looking.
+  return NextResponse.json({ ok: true, report: result.report });
+}

--- a/src/components/ConditionReportModal.test.tsx
+++ b/src/components/ConditionReportModal.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { ConditionReportModal } from './ConditionReportModal';
+import { MAP_EVENTS } from '@/events';
+
+const recordLocal = vi.fn();
+const refresh = vi.fn();
+
+vi.mock('@/components/TrailConditionsProvider', () => ({
+  useTrailConditions: () => ({
+    latest: {},
+    loading: false,
+    options: [
+      { color: '#16a34a', name: 'Dry', value: 'dry' },
+      {
+        color: '#b45309',
+        description: 'Soft enough to rut.',
+        name: 'Muddy — stay off',
+        value: 'muddy',
+      },
+    ],
+    recordLocal,
+    refresh,
+  }),
+}));
+
+/** Opens the form the way the elevation pane does. */
+function open(trailName = 'Pondo', slug = 'pondo') {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(MAP_EVENTS.CONDITION_REPORT_OPEN, {
+        detail: { slug, trailName },
+      }),
+    );
+  });
+}
+
+function mockFetch(response: { body: Record<string, unknown>; ok: boolean }) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: async () => response.body,
+    ok: response.ok,
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+describe('ConditionReportModal', () => {
+  beforeEach(() => {
+    recordLocal.mockClear();
+    refresh.mockClear();
+  });
+
+  it('renders nothing until asked to open', () => {
+    render(<ConditionReportModal />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens on the event, naming the trail', () => {
+    render(<ConditionReportModal />);
+    open();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Pondo')).toBeInTheDocument();
+  });
+
+  it('posts the slug, condition and date, then records the report locally', async () => {
+    const report = {
+      color: '#b45309',
+      name: 'Muddy — stay off',
+      observedAt: '2026-08-07T00:00:00.000Z',
+      source: 'public',
+      value: 'muddy',
+    };
+    const fetchMock = mockFetch({ body: { ok: true, report }, ok: true });
+
+    render(<ConditionReportModal />);
+    open();
+
+    fireEvent.change(screen.getByLabelText('Condition'), {
+      target: { value: 'muddy' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/map/conditions?city=');
+    expect(init.method).toBe('POST');
+
+    const body = JSON.parse(init.body as string);
+    expect(body.slug).toBe('pondo');
+    expect(body.condition).toBe('muddy');
+    expect(body.observedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // The honeypot must go out empty — a bot filling it is the only way it is
+    // ever anything else.
+    expect(body.website).toBe('');
+
+    await waitFor(() =>
+      expect(recordLocal).toHaveBeenCalledWith('pondo', report),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows the server’s message on a rate limit, and stays open', async () => {
+    mockFetch({
+      body: { error: 'That is 5 reports in an hour, which is our limit.' },
+      ok: false,
+    });
+
+    render(<ConditionReportModal />);
+    open();
+
+    fireEvent.change(screen.getByLabelText('Condition'), {
+      target: { value: 'dry' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }));
+
+    // The server writes these to be read by a person; inventing a generic
+    // message instead would drop the only explanation the rider gets.
+    expect(await screen.findByText(/5 reports in an hour/)).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(recordLocal).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing without a condition', () => {
+    const fetchMock = mockFetch({ body: { ok: true }, ok: true });
+
+    render(<ConditionReportModal />);
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /send report/i }));
+
+    // The `required` select stops the submit before the handler runs, which is
+    // why the assertion is on the absence of a request rather than on the
+    // handler's own "Pick a condition." message — that one is the fallback for
+    // a programmatic submit, not what a person sees.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Condition')).toBeInvalid();
+  });
+
+  it('shows the curator’s description for the chosen condition', () => {
+    render(<ConditionReportModal />);
+    open();
+
+    fireEvent.change(screen.getByLabelText('Condition'), {
+      target: { value: 'muddy' },
+    });
+
+    expect(screen.getByText('Soft enough to rut.')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    render(<ConditionReportModal />);
+    open();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ConditionReportModal.test.tsx
+++ b/src/components/ConditionReportModal.test.tsx
@@ -73,6 +73,7 @@ describe('ConditionReportModal', () => {
   it('posts the slug, condition and date, then records the report locally', async () => {
     const report = {
       color: '#b45309',
+      marksClosed: false,
       name: 'Muddy — stay off',
       observedAt: '2026-08-07T00:00:00.000Z',
       source: 'public',

--- a/src/components/ConditionReportModal.tsx
+++ b/src/components/ConditionReportModal.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+/**
+ * The report form: what it was like, and when. No account.
+ *
+ * Listens for `CONDITION_REPORT_OPEN` rather than taking props, so one copy at
+ * the page root serves every place that opens it.
+ *
+ * Nothing here is a real check — the server decides. What's here is the part
+ * that has to be in the markup (the honeypot) and enough to save a round trip.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { activeCityId } from '@/config/map.config';
+import { useTrailConditions } from '@/components/TrailConditionsProvider';
+import type { ConditionReport } from '@/data/trail-conditions';
+import { MAP_EVENTS } from '@/events';
+import { cn } from '@/lib/utils';
+
+/** `<input type="date">` wants `YYYY-MM-DD` in the *viewer's* timezone. */
+function toDateInputValue(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+interface OpenDetail {
+  slug: string;
+  trailName: string;
+}
+
+export function ConditionReportModal() {
+  const { options, recordLocal, refresh } = useTrailConditions();
+  const [target, setTarget] = useState<OpenDetail | null>(null);
+  const [condition, setCondition] = useState('');
+  const [observedAt, setObservedAt] = useState(() =>
+    toDateInputValue(new Date()),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const honeypotRef = useRef<HTMLInputElement>(null);
+  const selectRef = useRef<HTMLSelectElement>(null);
+
+  const close = useCallback(() => {
+    setTarget(null);
+    setError(null);
+    setSubmitting(false);
+  }, []);
+
+  useEffect(() => {
+    const handleOpen = (event: Event) => {
+      const detail = (event as CustomEvent).detail as OpenDetail;
+      setTarget(detail);
+      setError(null);
+      // Reset on every open, or a page left open past midnight offers
+      // yesterday as today.
+      setObservedAt(toDateInputValue(new Date()));
+    };
+    window.addEventListener(MAP_EVENTS.CONDITION_REPORT_OPEN, handleOpen);
+    return () =>
+      window.removeEventListener(MAP_EVENTS.CONDITION_REPORT_OPEN, handleOpen);
+  }, []);
+
+  // Escape closes, as it does for any dialog.
+  useEffect(() => {
+    if (!target) {
+      return;
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [target, close]);
+
+  // Focus the one field that needs an answer.
+  useEffect(() => {
+    if (target) {
+      selectRef.current?.focus();
+    }
+  }, [target]);
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!target || submitting) {
+      return;
+    }
+    if (!condition) {
+      setError('Pick a condition.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/map/conditions?city=${activeCityId}`, {
+        body: JSON.stringify({
+          condition,
+          observedAt,
+          slug: target.slug,
+          // Off the DOM: nothing types into this, so there's no onChange.
+          website: honeypotRef.current?.value ?? '',
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+
+      const data = (await response.json()) as {
+        error?: string;
+        report?: ConditionReport;
+      };
+
+      if (!response.ok) {
+        // The server's messages are written for a person; show them rather than
+        // inventing a generic one.
+        setError(data.error ?? 'That did not go through. Please try again.');
+        setSubmitting(false);
+        return;
+      }
+
+      if (data.report) {
+        recordLocal(target.slug, data.report);
+      } else {
+        // The honeypot path answers `{ ok: true }` with no report — unreachable
+        // for a real person, but a no-op beats a crash if it is reached.
+        refresh();
+      }
+
+      window.dispatchEvent(
+        new CustomEvent(MAP_EVENTS.TOAST, {
+          detail: { message: `Thanks — ${target.trailName} updated` },
+        }),
+      );
+      close();
+    } catch {
+      setError('Could not reach the server. Please try again.');
+      setSubmitting(false);
+    }
+  }
+
+  if (!target) {
+    return null;
+  }
+
+  const selected = options.find((option) => option.value === condition);
+
+  return (
+    <div className="fixed inset-0 z-[3000] flex items-center justify-center bg-black/60 backdrop-blur-[4px] px-5 py-10 animate-welcome-fade-in">
+      {/* Click-away as a real button behind the card, rather than a handler on
+          the backdrop. Hidden from assistive tech — the × is the close control,
+          and announcing two would be worse. */}
+      <button
+        aria-hidden="true"
+        className="absolute inset-0 cursor-default"
+        onClick={close}
+        tabIndex={-1}
+        type="button"
+      />
+      <div
+        aria-labelledby="condition-report-title"
+        aria-modal="true"
+        className="relative bg-white rounded-3xl w-full max-w-[380px] px-6 pt-5 pb-5 shadow-[0_24px_48px_rgba(0,0,0,0.25)] animate-welcome-slide-up"
+        role="dialog"
+      >
+        <div className="flex items-start gap-3 mb-4">
+          <div className="min-w-0">
+            <h2
+              className="text-lg font-bold text-app-secondary leading-tight"
+              id="condition-report-title"
+            >
+              How was it?
+            </h2>
+            <p className="text-[13px] text-gray-500 truncate">
+              {target.trailName}
+            </p>
+          </div>
+          <button
+            aria-label="Close"
+            className="ml-auto shrink-0 bg-transparent border-none cursor-pointer text-gray-400 text-xl px-1 hover:text-gray-600"
+            onClick={close}
+            type="button"
+          >
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+
+        <form onSubmit={submit}>
+          {/* The honeypot. Off-screen rather than `display: none`, which the
+              better bots skip, and unreachable by keyboard or screen reader so
+              nobody trips it by accident. */}
+          <input
+            aria-hidden="true"
+            autoComplete="off"
+            className="absolute left-[-9999px] w-px h-px opacity-0"
+            defaultValue=""
+            name="website"
+            ref={honeypotRef}
+            tabIndex={-1}
+            type="text"
+          />
+
+          <label
+            className="block text-[13px] font-semibold text-app-secondary mb-1"
+            htmlFor="condition-report-condition"
+          >
+            Condition
+          </label>
+          <select
+            className="w-full py-2 px-3 border border-gray-300 rounded-lg text-sm text-app-secondary bg-white outline-none focus:border-app-primary focus:ring-2 focus:ring-app-primary/30"
+            id="condition-report-condition"
+            onChange={(event) => setCondition(event.target.value)}
+            ref={selectRef}
+            required
+            value={condition}
+          >
+            <option disabled value="">
+              Pick one…
+            </option>
+            {options.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+          {/* The curator's own words for what this means locally. */}
+          {selected?.description && (
+            <p className="text-[11px] text-gray-500 mt-1">
+              {selected.description}
+            </p>
+          )}
+
+          <label
+            className="block text-[13px] font-semibold text-app-secondary mt-4 mb-1"
+            htmlFor="condition-report-date"
+          >
+            When did you ride it?
+          </label>
+          <input
+            className="w-full py-2 px-3 border border-gray-300 rounded-lg text-sm text-app-secondary bg-white outline-none focus:border-app-primary focus:ring-2 focus:ring-app-primary/30"
+            id="condition-report-date"
+            max={toDateInputValue(new Date())}
+            onChange={(event) => setObservedAt(event.target.value)}
+            type="date"
+            value={observedAt}
+          />
+
+          {error && (
+            <p className="text-[12px] text-red-600 mt-3" role="alert">
+              {error}
+            </p>
+          )}
+
+          <button
+            className={cn(
+              'w-full mt-5 py-2.5 rounded-xl border-none text-app-secondary font-semibold text-[15px] transition-opacity',
+              submitting
+                ? 'bg-gray-200 cursor-wait opacity-70'
+                : 'bg-app-primary cursor-pointer hover:opacity-90',
+            )}
+            disabled={submitting}
+            type="submit"
+          >
+            {submitting ? 'Sending…' : 'Send report'}
+          </button>
+          <p className="text-[11px] text-gray-400 text-center mt-2">
+            No account needed. Reports show on the map straight away.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -42,6 +42,7 @@ import {
   highlightMtnBikeArea,
   initMtnBikeColors,
   initMtnBikeLayers,
+  setClosedTrails,
   ensureMtnBikeSource,
   ensureOsmTrailsSource,
   setOsmTrailsVisible,
@@ -61,6 +62,8 @@ import {
 } from '@/utils/map';
 import { loadRide } from '@/utils/ride-storage';
 import { mapConfig } from '@/config/map.config';
+import { useTrailConditions } from '@/components/TrailConditionsProvider';
+import { closedTrails } from '@/data/trail-conditions';
 import { MAP_EVENTS } from '@/events';
 import { HeadingSmoother } from '@/utils/compass';
 
@@ -82,6 +85,10 @@ if (!mapConfig.mapbox.accessToken) {
 const MapboxMap = memo(function MapboxMap() {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map | null>(null);
+  // Set once, at the end of init, so the closures effect below knows there are
+  // layers to draw onto. Not a ref: this one has to trigger a render.
+  const [mapReady, setMapReady] = useState(false);
+  const { latest: latestConditions } = useTrailConditions();
   const locationMarker = useRef<mapboxgl.Marker | null>(null);
   const locationAccuracy = useRef<number>(0);
   const watchId = useRef<number | null>(null);
@@ -1188,6 +1195,7 @@ const MapboxMap = memo(function MapboxMap() {
           // Set a flag first so late listeners (e.g. page.tsx useEffect that
           // registers after this fires) can detect they missed the event.
           (window as unknown as Record<string, boolean>).__mapReady = true;
+          setMapReady(true);
           window.dispatchEvent(new Event(MAP_EVENTS.MAP_READY));
         } catch (error) {
           console.error('Error initializing map:', error);
@@ -1504,6 +1512,19 @@ const MapboxMap = memo(function MapboxMap() {
     // GPS/compass hook extraction.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Draw a red dashed line over any trail whose newest report says it is shut.
+  // Keyed on the conditions, not just the map, so a closure filed while the
+  // page is open appears without a reload.
+  useEffect(() => {
+    if (!mapReady || !map.current) {
+      return;
+    }
+    setClosedTrails(
+      map.current,
+      closedTrails({ latest: latestConditions }, getMountainBikeTrails()),
+    );
+  }, [mapReady, latestConditions]);
 
   return (
     <>

--- a/src/components/TrailConditionsProvider.tsx
+++ b/src/components/TrailConditionsProvider.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+/**
+ * The current condition of every trail, and the vocabulary to report a new one.
+ *
+ * Fetched on the client rather than passed down with the trails, for two
+ * reasons: the page is 60-second ISR, which is right for a trail's name and
+ * wrong for something meant to change during the day; and `MountainBikeTrail`
+ * is also the shape of the checked-in static data, which has no conditions.
+ */
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { activeCityId } from '@/config/map.config';
+import {
+  type ConditionOption,
+  type ConditionReport,
+  type ConditionSummary,
+  lockFor,
+} from '@/data/trail-conditions';
+
+interface TrailConditionsValue {
+  /** The newest visible report per trail slug. Absent means nobody has said. */
+  latest: Record<string, ConditionReport>;
+  /** True until the first fetch settles, either way. */
+  loading: boolean;
+  /**
+   * Why a trail is not taking reports, or null. Wraps the three switches so
+   * callers can't get the precedence wrong. Only decides whether to offer the
+   * button — the server enforces the same rule on submit.
+   */
+  lockedReason: (slug: string) => null | string;
+  options: ConditionOption[];
+  /** Merge a just-filed report so the badge updates without waiting on a fetch. */
+  recordLocal: (slug: string, report: ConditionReport) => void;
+  /** Re-read from the server. */
+  refresh: () => void;
+}
+
+/** Open, for the same reason `NO_SUMMARY` is: a failure is not a closure. */
+const NO_SUMMARY: ConditionSummary = {
+  latest: {},
+  locked: {},
+  options: [],
+  reporting: { enabled: true, message: '' },
+};
+
+const EMPTY: TrailConditionsValue = {
+  latest: {},
+  loading: false,
+  lockedReason: () => null,
+  options: [],
+  recordLocal: () => {},
+  refresh: () => {},
+};
+
+const TrailConditionsContext = createContext<TrailConditionsValue>(EMPTY);
+
+/**
+ * Why there is no error state: a component outside the provider, or one mounted
+ * while the fetch is failing, gets `EMPTY` — which looks exactly like a map
+ * nobody has reported on. Conditions must never stop something rendering.
+ */
+export function useTrailConditions(): TrailConditionsValue {
+  return useContext(TrailConditionsContext);
+}
+
+export function TrailConditionsProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  const [summary, setSummary] = useState<ConditionSummary>(NO_SUMMARY);
+  const [loading, setLoading] = useState(true);
+  const [reloads, setReloads] = useState(0);
+
+  const refresh = useCallback(() => setReloads((n) => n + 1), []);
+
+  /**
+   * Reports filed from this page, layered back over every server response.
+   *
+   * A refresh right after a submission can race the GET's 30-second cache and
+   * come back without the report the rider just filed, which reads as failure.
+   * Never cleared, so one an admin hides stays visible to its author until they
+   * reload — the better way to be wrong.
+   */
+  const localRef = useRef<Record<string, ConditionReport>>({});
+
+  const recordLocal = useCallback((slug: string, report: ConditionReport) => {
+    localRef.current = { ...localRef.current, [slug]: report };
+    setSummary((prev) => ({
+      ...prev,
+      latest: { ...prev.latest, [slug]: report },
+    }));
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    // `async` so a synchronous throw out of `fetch` is caught alongside a
+    // network failure. This provider wraps the whole map, and an exception
+    // escaping the effect would take it down.
+    async function load() {
+      try {
+        const response = await fetch(
+          `/api/map/conditions?city=${activeCityId}`,
+          { signal: controller.signal },
+        );
+        const data: ConditionSummary | null = response?.ok
+          ? await response.json()
+          : null;
+
+        if (data) {
+          setSummary({
+            ...data,
+            latest: { ...data.latest, ...localRef.current },
+            // An older deployment answering without these must not read as
+            // "everything is closed".
+            locked: data.locked ?? {},
+            reporting: data.reporting ?? { enabled: true, message: '' },
+          });
+        }
+        setLoading(false);
+      } catch (error) {
+        // An abort is cleanup, not a failure; the component is on its way out.
+        if ((error as Error)?.name !== 'AbortError') {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => controller.abort();
+  }, [reloads]);
+
+  const value = useMemo(
+    () => ({
+      latest: summary.latest,
+      loading,
+      lockedReason: (slug: string) => lockFor(summary, slug),
+      options: summary.options,
+      recordLocal,
+      refresh,
+    }),
+    [summary, loading, recordLocal, refresh],
+  );
+
+  return (
+    <TrailConditionsContext.Provider value={value}>
+      {children}
+    </TrailConditionsContext.Provider>
+  );
+}

--- a/src/components/sidebar/ConditionBadge.tsx
+++ b/src/components/sidebar/ConditionBadge.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils';
 import {
   type ConditionReport,
   conditionAgeLabel,
-  isConditionFresh,
+  isConditionCurrent,
 } from '@/data/trail-conditions';
 
 export function ConditionBadge({
@@ -26,7 +26,7 @@ export function ConditionBadge({
   showAge?: boolean;
   size?: 'md' | 'sm';
 }) {
-  if (!report || !isConditionFresh(report.observedAt)) {
+  if (!report || !isConditionCurrent(report)) {
     return null;
   }
 

--- a/src/components/sidebar/ConditionBadge.tsx
+++ b/src/components/sidebar/ConditionBadge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * The pill saying what a trail was last like.
+ *
+ * Shared by the sidebar and the pane so both hide a stale report on the same
+ * rule. Colour comes off the vocabulary row, so recolouring a condition in the
+ * admin repaints every badge.
+ */
+import { cn } from '@/lib/utils';
+import {
+  type ConditionReport,
+  conditionAgeLabel,
+  isConditionFresh,
+} from '@/data/trail-conditions';
+
+export function ConditionBadge({
+  className,
+  report,
+  showAge = false,
+  size = 'sm',
+}: {
+  className?: string;
+  report: ConditionReport | undefined;
+  /** Append "· 2 days ago". The pane has room for it; a list row does not. */
+  showAge?: boolean;
+  size?: 'md' | 'sm';
+}) {
+  if (!report || !isConditionFresh(report.observedAt)) {
+    return null;
+  }
+
+  const age = conditionAgeLabel(report.observedAt);
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full font-medium whitespace-nowrap shrink-0',
+        size === 'sm' ? 'text-[10px] px-1.5 py-px' : 'text-[11px] px-2 py-0.5',
+        className,
+      )}
+      style={{
+        // Tinted from the one colour so a curator only picks one and any new
+        // condition still gets a legible badge.
+        backgroundColor: `${report.color}1f`,
+        color: report.color,
+      }}
+      title={
+        report.source === 'admin'
+          ? `${report.name} — reported by the trail steward, ${age}`
+          : `${report.name} — reported by a rider, ${age}`
+      }
+    >
+      {/* A steward's word, not a rider's guess. */}
+      {report.source === 'admin' && <span aria-hidden="true">★</span>}
+      {report.name}
+      {showAge && <span className="font-normal opacity-70">· {age}</span>}
+    </span>
+  );
+}

--- a/src/components/sidebar/ElevationProfile.test.tsx
+++ b/src/components/sidebar/ElevationProfile.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   gradeToColor,
   computeGradeColors,
+  computeGrades,
   downsampleStops,
+  formatGrade,
+  MAX_GRADIENT_STOPS,
   findClosestProfileIndex,
   profilePointToXY,
 } from './ElevationProfile';
@@ -86,12 +89,12 @@ describe('downsampleStops', () => {
     expect(stops).toHaveLength(50);
   });
 
-  it('returns exactly 200 stops when count is > 200', () => {
-    const points = makePoints(500);
+  it('caps the stop count on a profile longer than the cap', () => {
+    const points = makePoints(MAX_GRADIENT_STOPS + 100);
     const colors = points.map(() => 'rgb(34,197,94)');
     const maxDist = points[points.length - 1][0];
     const stops = downsampleStops(points, colors, maxDist);
-    expect(stops).toHaveLength(200);
+    expect(stops).toHaveLength(MAX_GRADIENT_STOPS);
   });
 
   it('first offset is 0 and last is approximately 1', () => {
@@ -177,5 +180,66 @@ describe('profilePointToXY', () => {
     };
     const { y } = profilePointToXY(points, 0, flatProfile, 800);
     expect(Number.isFinite(y)).toBe(true);
+  });
+});
+
+describe('computeGrades', () => {
+  // 10 ft up over 100 ft along = 10%.
+  const climb: [number, number, number, number][] = [
+    [0, 100, -85, 35],
+    [100, 110, -85, 35],
+    [200, 120, -85, 35],
+    [300, 130, -85, 35],
+    [400, 140, -85, 35],
+  ];
+
+  it('reads a steady grade correctly', () => {
+    const grades = computeGrades(climb);
+    // The interior points have a full window either side, so they land on 10.
+    expect(grades[2]).toBeCloseTo(10, 5);
+  });
+
+  it('signs a descent negative', () => {
+    const drop: [number, number, number, number][] = climb.map(
+      ([d, e, lng, lat]) => [d, 200 - e, lng, lat],
+    );
+    expect(computeGrades(drop)[2]).toBeCloseTo(-10, 5);
+  });
+
+  it('keeps a short pitch visible rather than averaging it away', () => {
+    // One steep step in otherwise flat ground. With the old ±2 window this
+    // was divided across five samples; the point of the smaller window is
+    // that the pitch still reads as steep.
+    const pitch: [number, number, number, number][] = [
+      [0, 100, -85, 35],
+      [100, 100, -85, 35],
+      [200, 130, -85, 35],
+      [300, 130, -85, 35],
+      [400, 130, -85, 35],
+    ];
+    expect(Math.max(...computeGrades(pitch))).toBeGreaterThan(9);
+  });
+
+  it('is one grade per point, and flat for a degenerate profile', () => {
+    expect(computeGrades(climb)).toHaveLength(climb.length);
+    expect(computeGrades([[0, 100, -85, 35]])).toEqual([0]);
+    expect(computeGrades([])).toEqual([]);
+  });
+});
+
+describe('formatGrade', () => {
+  it('signs the number, because up and down share a colour', () => {
+    expect(formatGrade(8.42)).toBe('+8.4%');
+    expect(formatGrade(-8.42)).toBe('−8.4%');
+  });
+
+  it('does not dress up a zero', () => {
+    expect(formatGrade(0)).toBe('0.0%');
+    expect(formatGrade(0.01)).toBe('0.0%');
+  });
+
+  it('degrades rather than printing NaN', () => {
+    expect(formatGrade(undefined)).toBe('—');
+    expect(formatGrade(Number.NaN)).toBe('—');
   });
 });

--- a/src/components/sidebar/ElevationProfile.tsx
+++ b/src/components/sidebar/ElevationProfile.tsx
@@ -27,6 +27,8 @@ import { cn } from '@/lib/utils';
 import { getSetting } from '@/utils/settings';
 import { siteConfig } from '@/config/site.config';
 import { TOGGLE_BTN_CLASS, TOGGLE_ICON_CLASS } from '@/components/styles';
+import { useTrailConditions } from '@/components/TrailConditionsProvider';
+import { TrailConditionsStrip } from './TrailConditionsStrip';
 
 const CHART_HEIGHT = 100;
 const CHART_PADDING_TOP = 4;
@@ -56,6 +58,20 @@ function profileSlug(trailName: string): string {
     (item) => item.trailName === trailName,
   );
   return trail ? slugForTrail(trail) : slugify(trailName);
+}
+
+/**
+ * The slug conditions are keyed by, or null.
+ *
+ * Stricter than `profileSlug`, which invents one for an unrecognised name.
+ * Conditions attach to a curated trail, so an OSM way, a route or a ride has
+ * none — guessing would key reports against a trail that doesn't exist.
+ */
+function curatedSlug(trailName: string): string | null {
+  const trail = getMountainBikeTrails().find(
+    (item) => item.trailName === trailName,
+  );
+  return trail ? slugForTrail(trail) : null;
 }
 const MAX_GRADIENT_STOPS = 200;
 
@@ -209,6 +225,10 @@ export function findClosestProfileIndex(
 export function ElevationProfile() {
   const [trailName, setTrailName] = useState<string | null>(null);
   const [profile, setProfile] = useState<ElevationProfileData | null>(null);
+  // The curated trail conditions are shown for, if this selection is one. State
+  // rather than derived from `trailName`, since a ride and an OSM way both put
+  // a name there and neither has conditions.
+  const [conditionSlug, setConditionSlug] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   const [locationIndex, setLocationIndex] = useState<number | null>(null);
@@ -226,12 +246,16 @@ export function ElevationProfile() {
 
   const [collapsed, setCollapsed] = useState(false);
 
+  // Only to decide whether the pane has conditions worth opening for.
+  const { options: conditionOptions } = useTrailConditions();
+
   useEffect(() => {
     const handleTrailSelect = (e: Event) => {
       const { trailName: name } = (e as CustomEvent).detail;
       sourceRef.current = 'trail';
       rideIdRef.current = null;
       setTrailName(name);
+      setConditionSlug(curatedSlug(name));
       window.history.replaceState(
         null,
         '',
@@ -250,6 +274,8 @@ export function ElevationProfile() {
       rideIdRef.current = null;
       profileCache.set(osmProfile.trail, osmProfile);
       setTrailName(osmProfile.trail);
+      // An OSM way has no row to hang reports on, even if its name matches one.
+      setConditionSlug(null);
       setProfile(osmProfile);
       profileRef.current = osmProfile;
       setHoverIndex(null);
@@ -298,6 +324,8 @@ export function ElevationProfile() {
       const elevProfile = rideToElevationProfile(ride);
       sourceRef.current = 'ride';
       rideIdRef.current = rideId;
+      // A ride is not a trail anyone reports on.
+      setConditionSlug(null);
       if (elevProfile) {
         setTrailName(ride.name);
         profileCache.set(ride.name, elevProfile);
@@ -542,12 +570,24 @@ export function ElevationProfile() {
   const hasProfile =
     !!trailName && !loading && !!profile && profile.profile.length >= 2;
 
-  if (!hasProfile) {
+  /**
+   * The pane's second reason to open. It used to need a chart, which would have
+   * hidden conditions on exactly the trails nobody has curated yet — every
+   * Chattanooga trail, and any whose ways Overpass couldn't resolve.
+   *
+   * `conditionOptions` is in the test because with no database there is no
+   * vocabulary, and the pane must not open on an empty strip.
+   */
+  const hasConditions =
+    !!trailName && !!conditionSlug && conditionOptions.length > 0;
+
+  if (!hasProfile && !hasConditions) {
     return null;
   }
 
-  const points = profile.profile;
-  const maxDist = points[points.length - 1][0];
+  // No longer narrowed off `hasProfile`, which is no longer the only way past
+  // the guard above.
+  const points = hasProfile && profile ? profile.profile : null;
 
   // Mountain icon toggle button (visible when collapsed)
   if (collapsed) {
@@ -562,7 +602,9 @@ export function ElevationProfile() {
           onClick={() => setCollapsed(false)}
           className={TOGGLE_BTN_CLASS}
           type="button"
-          title="Show elevation profile"
+          title={
+            hasProfile ? 'Show elevation profile' : 'Show trail conditions'
+          }
         >
           <FontAwesomeIcon icon={faChartArea} className={TOGGLE_ICON_CLASS} />
         </button>
@@ -599,11 +641,15 @@ export function ElevationProfile() {
             {trailName}
           </span>
         )}
-        <div className="flex gap-3 text-[11px] text-gray-500 ml-auto shrink-0">
-          <span>{(maxDist / 5280).toFixed(1)} mi</span>
-          <span>+{Math.round(profile.gain).toLocaleString()} ft climbing</span>
-        </div>
-        <div className="flex gap-1 ml-2 shrink-0">
+        {points && profile && (
+          <div className="flex gap-3 text-[11px] text-gray-500 ml-auto shrink-0">
+            <span>{(points[points.length - 1][0] / 5280).toFixed(1)} mi</span>
+            <span>
+              +{Math.round(profile.gain).toLocaleString()} ft climbing
+            </span>
+          </div>
+        )}
+        <div className={cn('flex gap-1 shrink-0', points ? 'ml-2' : 'ml-auto')}>
           <button
             type="button"
             className={ACTION_BTN_CLASS}
@@ -619,14 +665,17 @@ export function ElevationProfile() {
           >
             <FontAwesomeIcon icon={faShareAlt} />
           </button>
-          <button
-            type="button"
-            className={ACTION_BTN_CLASS}
-            onClick={() => downloadGpx(profile)}
-            title="Download GPX"
-          >
-            <FontAwesomeIcon icon={faDownload} />
-          </button>
+          {/* Nothing to export when the pane is open for conditions alone. */}
+          {profile && points && (
+            <button
+              type="button"
+              className={ACTION_BTN_CLASS}
+              onClick={() => downloadGpx(profile)}
+              title="Download GPX"
+            >
+              <FontAwesomeIcon icon={faDownload} />
+            </button>
+          )}
           <button
             type="button"
             className={ACTION_BTN_CLASS}
@@ -638,7 +687,12 @@ export function ElevationProfile() {
         </div>
       </div>
 
-      {profile.osm && (
+      {/* Where the OSM tag strip sits: describes the trail, doesn't measure it. */}
+      {hasConditions && conditionSlug && trailName && (
+        <TrailConditionsStrip slug={conditionSlug} trailName={trailName} />
+      )}
+
+      {profile?.osm && (
         <div className="flex items-center gap-2 text-[10px] text-gray-500 mb-1 -mt-0.5">
           <span className="truncate capitalize">
             {[
@@ -663,54 +717,58 @@ export function ElevationProfile() {
         </div>
       )}
 
-      <div className="flex relative">
-        <div className="flex flex-col justify-between py-0.5 shrink-0 w-[42px]">
-          <span className="text-[9px] text-gray-400 text-right pr-1 leading-none">
-            {Math.round(profile.max).toLocaleString()} ft
-          </span>
-          <span className="text-[9px] text-gray-400 text-right pr-1 leading-none">
-            {Math.round(profile.min).toLocaleString()} ft
-          </span>
-        </div>
+      {points && profile && (
+        <div className="flex relative">
+          <div className="flex flex-col justify-between py-0.5 shrink-0 w-[42px]">
+            <span className="text-[9px] text-gray-400 text-right pr-1 leading-none">
+              {Math.round(profile.max).toLocaleString()} ft
+            </span>
+            <span className="text-[9px] text-gray-400 text-right pr-1 leading-none">
+              {Math.round(profile.min).toLocaleString()} ft
+            </span>
+          </div>
 
-        <div className="relative flex-1">
-          <ElevationSvg
-            points={points}
-            gradeColors={gradeColors}
-            profile={profile}
-            chartWidth={chartWidth}
-            svgRef={svgRef}
-            onMouseMove={handleMouseMove}
-            onMouseLeave={clearHover}
-            onTouchStart={handleTouch}
-            onTouchMove={handleTouch}
-            onTouchEnd={clearHover}
-          />
-          {locationIndex !== null && (
-            <LocationIndicator
-              points={points}
-              profile={profile}
-              chartWidth={chartWidth}
-              locationIndex={locationIndex}
-            />
-          )}
-          {hoverIndex !== null && (
-            <HoverIndicator
+          <div className="relative flex-1">
+            <ElevationSvg
               points={points}
               gradeColors={gradeColors}
               profile={profile}
               chartWidth={chartWidth}
-              hoverIndex={hoverIndex}
+              svgRef={svgRef}
+              onMouseMove={handleMouseMove}
+              onMouseLeave={clearHover}
+              onTouchStart={handleTouch}
+              onTouchMove={handleTouch}
+              onTouchEnd={clearHover}
             />
-          )}
+            {locationIndex !== null && (
+              <LocationIndicator
+                points={points}
+                profile={profile}
+                chartWidth={chartWidth}
+                locationIndex={locationIndex}
+              />
+            )}
+            {hoverIndex !== null && (
+              <HoverIndicator
+                points={points}
+                gradeColors={gradeColors}
+                profile={profile}
+                chartWidth={chartWidth}
+                hoverIndex={hoverIndex}
+              />
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="text-[11px] text-gray-600 text-center py-0.5 min-h-4">
-        {hoverIndex !== null
-          ? `${(points[hoverIndex][0] / 5280).toFixed(2)} mi \u00B7 ${Math.round(points[hoverIndex][1]).toLocaleString()} ft`
-          : '\u00A0'}
-      </div>
+      {points && (
+        <div className="text-[11px] text-gray-600 text-center py-0.5 min-h-4">
+          {hoverIndex !== null
+            ? `${(points[hoverIndex][0] / 5280).toFixed(2)} mi \u00B7 ${Math.round(points[hoverIndex][1]).toLocaleString()} ft`
+            : '\u00A0'}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/sidebar/ElevationProfile.tsx
+++ b/src/components/sidebar/ElevationProfile.tsx
@@ -73,7 +73,15 @@ function curatedSlug(trailName: string): string | null {
   );
   return trail ? slugForTrail(trail) : null;
 }
-const MAX_GRADIENT_STOPS = 200;
+/**
+ * Colour stops per chart.
+ *
+ * The other place grade detail is lost: a 2,000-point trail capped at 200 stops
+ * averages away roughly every short pitch. Raising it keeps them, at the cost
+ * of more nodes in one `<linearGradient>` — cheap, since the gradient is
+ * memoised and only rebuilds when the profile or width changes.
+ */
+export const MAX_GRADIENT_STOPS = 600;
 
 const CHART_SVG_CLASS =
   'w-full h-[15vh] min-h-[80px] max-h-[160px] cursor-crosshair rounded touch-none';
@@ -96,10 +104,39 @@ export function gradeToColor(grade: number): string {
   return `rgb(${r},${green},${b})`;
 }
 
-export function computeGradeColors(
+/**
+ * Samples either side of a point averaged into its grade.
+ *
+ * Some smoothing is needed: Terrain-RGB elevation is quantised, so a raw
+ * sample-to-sample grade over a short step is mostly noise and the chart comes
+ * out as confetti. But every sample folded in also flattens the short steep
+ * pitches that are the interesting part of a trail. 1 (a 3-sample average) is
+ * the compromise; 0 is raw, 2 was the old default.
+ */
+export const GRADE_SMOOTHING_WINDOW = 1;
+
+/**
+ * A grade for the hover readout — signed, one decimal.
+ *
+ * The sign is the point: 8% up and 8% down are the same colour on the chart
+ * (`gradeToColor` takes the absolute value) and very different to ride.
+ */
+export function formatGrade(grade: number | undefined): string {
+  if (grade === undefined || !Number.isFinite(grade)) {
+    return '—';
+  }
+  // Rounds to nothing either way, so don't dress it up with a sign.
+  if (Math.abs(grade) < 0.05) {
+    return '0.0%';
+  }
+  return `${grade > 0 ? '+' : '\u2212'}${Math.abs(grade).toFixed(1)}%`;
+}
+
+/** Percent grade at each point, smoothed. Positive is uphill. */
+export function computeGrades(
   points: [number, number, number, number][],
-): string[] {
-  if (points.length < 2) return points.map(() => gradeToColor(0));
+): number[] {
+  if (points.length < 2) return points.map(() => 0);
 
   const rawGrades: number[] = [0];
   for (let i = 1; i < points.length; i++) {
@@ -108,14 +145,15 @@ export function computeGradeColors(
     rawGrades.push(dx > 0 ? (dy / dx) * 100 : 0);
   }
 
+  if (GRADE_SMOOTHING_WINDOW <= 0) return rawGrades;
+
   const smoothed: number[] = [];
-  const WINDOW = 2;
   for (let i = 0; i < rawGrades.length; i++) {
     let sum = 0;
     let count = 0;
     for (
-      let j = Math.max(0, i - WINDOW);
-      j <= Math.min(rawGrades.length - 1, i + WINDOW);
+      let j = Math.max(0, i - GRADE_SMOOTHING_WINDOW);
+      j <= Math.min(rawGrades.length - 1, i + GRADE_SMOOTHING_WINDOW);
       j++
     ) {
       sum += rawGrades[j];
@@ -124,7 +162,14 @@ export function computeGradeColors(
     smoothed.push(sum / count);
   }
 
-  return smoothed.map((g) => gradeToColor(g));
+  return smoothed;
+}
+
+export function computeGradeColors(
+  points: [number, number, number, number][],
+): string[] {
+  if (points.length < 2) return points.map(() => gradeToColor(0));
+  return computeGrades(points).map((g) => gradeToColor(g));
 }
 
 // Force strictly increasing offsets. Consecutive profile points can share a
@@ -562,9 +607,13 @@ export function ElevationProfile() {
     );
   }, []);
 
-  const gradeColors = useMemo(
-    () => (profile ? computeGradeColors(profile.profile) : []),
+  const grades = useMemo(
+    () => (profile ? computeGrades(profile.profile) : []),
     [profile],
+  );
+  const gradeColors = useMemo(
+    () => grades.map((g) => gradeToColor(g)),
+    [grades],
   );
 
   const hasProfile =
@@ -764,9 +813,18 @@ export function ElevationProfile() {
 
       {points && (
         <div className="text-[11px] text-gray-600 text-center py-0.5 min-h-4">
-          {hoverIndex !== null
-            ? `${(points[hoverIndex][0] / 5280).toFixed(2)} mi \u00B7 ${Math.round(points[hoverIndex][1]).toLocaleString()} ft`
-            : '\u00A0'}
+          {hoverIndex !== null ? (
+            <>
+              {`${(points[hoverIndex][0] / 5280).toFixed(2)} mi \u00B7 ${Math.round(points[hoverIndex][1]).toLocaleString()} ft \u00B7 `}
+              {/* Coloured to match the chart under the cursor, so the number
+                  and the band it came from are visibly the same reading. */}
+              <span style={{ color: gradeColors[hoverIndex] }}>
+                {formatGrade(grades[hoverIndex])}
+              </span>
+            </>
+          ) : (
+            '\u00A0'
+          )}
         </div>
       )}
     </div>

--- a/src/components/sidebar/MountainBikeTrails.conditions.test.tsx
+++ b/src/components/sidebar/MountainBikeTrails.conditions.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MountainBikeTrails } from './MountainBikeTrails';
+import type { ConditionReport } from '@/data/trail-conditions';
+import type { MountainBikeTrailsProps } from './types';
+
+/**
+ * The badge on a sidebar row, and specifically the staleness rule.
+ *
+ * The rule is the part worth a test: a report that is shown when it should not
+ * be is worse than one that is missing, because someone reads a green pill from
+ * last season as today's answer and drives out on it.
+ */
+
+vi.mock('@/data/trail-source', () => ({
+  getMountainBikeTrails: () => [
+    {
+      color: '#16A34A',
+      displayName: 'Fresh Trail',
+      icon: {},
+      rating: 'easy',
+      recArea: 'Area 1',
+      slug: 'fresh-trail',
+      trailName: 'Fresh Trail',
+    },
+    {
+      color: '#16A34A',
+      displayName: 'Stale Trail',
+      icon: {},
+      rating: 'easy',
+      recArea: 'Area 1',
+      slug: 'stale-trail',
+      trailName: 'Stale Trail',
+    },
+    {
+      color: '#16A34A',
+      displayName: 'Quiet Trail',
+      icon: {},
+      rating: 'easy',
+      recArea: 'Area 1',
+      slug: 'quiet-trail',
+      trailName: 'Quiet Trail',
+    },
+  ],
+}));
+
+vi.mock('@/data/geo_data', () => ({ regionFor: () => 'Region 1' }));
+
+function report(daysAgo: number, name: string): ConditionReport {
+  const observed = new Date();
+  observed.setDate(observed.getDate() - daysAgo);
+  return {
+    color: '#b45309',
+    name,
+    observedAt: observed.toISOString(),
+    source: 'public',
+    value: 'muddy',
+  };
+}
+
+const latest: Record<string, ConditionReport> = {
+  'fresh-trail': report(2, 'Muddy — stay off'),
+  // 20 days is past CONDITION_FRESH_DAYS.
+  'stale-trail': report(20, 'Dry'),
+};
+
+vi.mock('@/components/TrailConditionsProvider', () => ({
+  useTrailConditions: () => ({
+    latest,
+    loading: false,
+    options: [],
+    recordLocal: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+const defaultProps: MountainBikeTrailsProps = {
+  onAreaSelect: vi.fn(),
+  onTrailSelect: vi.fn(),
+  selectedTrail: null,
+};
+
+describe('MountainBikeTrails condition badges', () => {
+  it('shows a badge for a recent report', () => {
+    render(
+      <MountainBikeTrails {...defaultProps} selectedTrail="Fresh Trail" />,
+    );
+
+    expect(screen.getByText('Muddy — stay off')).toBeInTheDocument();
+  });
+
+  it('shows nothing for a report past the freshness cutoff', () => {
+    render(
+      <MountainBikeTrails {...defaultProps} selectedTrail="Stale Trail" />,
+    );
+
+    // Scoped to the row: selecting a trail expands its whole complex, so the
+    // other trails' badges are on screen too.
+    const row = screen.getByRole('button', { name: /Stale Trail/ });
+    expect(within(row).queryByText('Dry')).not.toBeInTheDocument();
+  });
+
+  it('shows nothing for a trail nobody has reported on', () => {
+    render(
+      <MountainBikeTrails {...defaultProps} selectedTrail="Quiet Trail" />,
+    );
+
+    const row = screen.getByRole('button', { name: /Quiet Trail/ });
+    expect(row).toHaveTextContent('Quiet Trail');
+    expect(within(row).queryByText(/Muddy/)).not.toBeInTheDocument();
+  });
+
+  it('keys reports by slug, not by display name', () => {
+    // `slug` differs from a slugified `trailName` often enough that getting
+    // this wrong would silently show every trail no badge at all.
+    render(
+      <MountainBikeTrails {...defaultProps} selectedTrail="Fresh Trail" />,
+    );
+
+    const row = screen.getByRole('button', { name: /Fresh Trail/ });
+    expect(row).toHaveTextContent('Muddy — stay off');
+  });
+});

--- a/src/components/sidebar/MountainBikeTrails.conditions.test.tsx
+++ b/src/components/sidebar/MountainBikeTrails.conditions.test.tsx
@@ -52,6 +52,7 @@ function report(daysAgo: number, name: string): ConditionReport {
   observed.setDate(observed.getDate() - daysAgo);
   return {
     color: '#b45309',
+    marksClosed: false,
     name,
     observedAt: observed.toISOString(),
     source: 'public',

--- a/src/components/sidebar/MountainBikeTrails.tsx
+++ b/src/components/sidebar/MountainBikeTrails.tsx
@@ -7,8 +7,11 @@ import {
 import { cn } from '@/lib/utils';
 import { regionOf } from '@/data/trail-region';
 import { getMountainBikeTrails } from '@/data/trail-source';
+import { useTrailConditions } from '@/components/TrailConditionsProvider';
+import { ConditionBadge } from './ConditionBadge';
 import type { MountainBikeTrailsProps } from './types';
 import type { MountainBikeTrail } from '@/data/mountain-bike-trails';
+import { slugForTrail } from '@/data/mountain-bike-trails';
 
 /**
  * Groups the current trail list region -> area -> trails, with a trail count
@@ -91,6 +94,10 @@ function TrailRow({
   selectedTrail: string | null;
   onTrailSelect: (name: string) => void;
 }) {
+  // Keyed by slug, not name: two complexes can both have a "Larry".
+  const { latest } = useTrailConditions();
+  const condition = latest[slugForTrail(trail)];
+
   return (
     <div
       onClick={() => onTrailSelect(trail.trailName)}
@@ -119,7 +126,11 @@ function TrailRow({
           className={shapeFor(trail.rating)}
           style={{ backgroundColor: trail.color }}
         />
-        <span className="font-medium text-[13px]">{trail.displayName}</span>
+        <span className="font-medium text-[13px] min-w-0 truncate">
+          {trail.displayName}
+        </span>
+        {/* Beside the name — the stats already own the right-hand side. */}
+        <ConditionBadge report={condition} />
         {trail.distance || trail.elevationGain ? (
           <span className="text-[11px] text-gray-500 ml-auto shrink-0">
             {trail.distance ? `${trail.distance} mi` : ''}

--- a/src/components/sidebar/TrailConditionsStrip.test.tsx
+++ b/src/components/sidebar/TrailConditionsStrip.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TrailConditionsStrip } from './TrailConditionsStrip';
+import type { ConditionReport } from '@/data/trail-conditions';
+import { MAP_EVENTS } from '@/events';
+
+/**
+ * What a rider can do on a trail that is, or is not, taking reports.
+ *
+ * The lock only hides the button — the server is what actually refuses a POST —
+ * so what these check is the promise made alongside it: that closing reports
+ * does not also hide what has already been reported.
+ */
+
+const lockedReason = vi.fn<(slug: string) => null | string>(() => null);
+
+const fresh: ConditionReport = {
+  color: '#b45309',
+  name: 'Muddy — stay off',
+  observedAt: new Date().toISOString(),
+  source: 'public',
+  value: 'muddy',
+};
+
+vi.mock('@/components/TrailConditionsProvider', () => ({
+  useTrailConditions: () => ({
+    latest: { pondo: fresh },
+    loading: false,
+    lockedReason,
+    options: [{ color: '#16a34a', name: 'Dry', value: 'dry' }],
+    recordLocal: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+function renderStrip() {
+  return render(<TrailConditionsStrip slug="pondo" trailName="Pondo" />);
+}
+
+describe('TrailConditionsStrip', () => {
+  beforeEach(() => {
+    lockedReason.mockReset();
+    lockedReason.mockReturnValue(null);
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ reports: [] }),
+      ok: true,
+    }) as unknown as typeof fetch;
+  });
+
+  it('offers the report button when the trail is open', () => {
+    renderStrip();
+    expect(screen.getByRole('button', { name: /report/i })).toBeInTheDocument();
+  });
+
+  it('dispatches CONDITION_REPORT_OPEN with the slug and name', () => {
+    const listener = vi.fn();
+    window.addEventListener(MAP_EVENTS.CONDITION_REPORT_OPEN, listener);
+
+    renderStrip();
+    fireEvent.click(screen.getByRole('button', { name: /report/i }));
+
+    expect(listener).toHaveBeenCalled();
+    const detail = (listener.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toEqual({ slug: 'pondo', trailName: 'Pondo' });
+
+    window.removeEventListener(MAP_EVENTS.CONDITION_REPORT_OPEN, listener);
+  });
+
+  it('replaces the button with the steward’s note when locked', () => {
+    lockedReason.mockReturnValue('Closed for logging until 1 May.');
+    renderStrip();
+
+    expect(
+      screen.queryByRole('button', { name: /report/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Closed for logging until 1 May.'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps showing the current condition while locked', () => {
+    // The whole point of not hiding conditions on a closed trail: knowing it is
+    // shut, and what it was like, is the most useful thing on the page.
+    lockedReason.mockReturnValue('Closed for logging until 1 May.');
+    renderStrip();
+
+    expect(screen.getByText('Muddy — stay off')).toBeInTheDocument();
+  });
+
+  it('keeps the history open while locked', () => {
+    lockedReason.mockReturnValue('Closed for logging until 1 May.');
+    renderStrip();
+
+    expect(
+      screen.getByRole('button', { name: /history/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('stops inviting a report the trail will not take', async () => {
+    lockedReason.mockReturnValue('Closed for logging until 1 May.');
+    renderStrip();
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+
+    expect(await screen.findByText('Nothing reported.')).toBeInTheDocument();
+    expect(screen.queryByText(/Ridden it lately/)).not.toBeInTheDocument();
+  });
+
+  it('does invite one when the trail is open', async () => {
+    renderStrip();
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+
+    expect(await screen.findByText(/Ridden it lately/)).toBeInTheDocument();
+  });
+});

--- a/src/components/sidebar/TrailConditionsStrip.test.tsx
+++ b/src/components/sidebar/TrailConditionsStrip.test.tsx
@@ -17,6 +17,7 @@ const lockedReason = vi.fn<(slug: string) => null | string>(() => null);
 
 const fresh: ConditionReport = {
   color: '#b45309',
+  marksClosed: false,
   name: 'Muddy — stay off',
   observedAt: new Date().toISOString(),
   source: 'public',

--- a/src/components/sidebar/TrailConditionsStrip.tsx
+++ b/src/components/sidebar/TrailConditionsStrip.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+/**
+ * Conditions in the selected-trail pane: what it is like now, what it has been
+ * like, and the way to say what you found.
+ *
+ * One line under the pane header, like the OSM tag strip beside it. The report
+ * button stays even with no reports — an unreported trail is the one worth
+ * asking about.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faChevronDown,
+  faChevronRight,
+  faLock,
+  faPenToSquare,
+} from '@fortawesome/free-solid-svg-icons';
+import { activeCityId } from '@/config/map.config';
+import { useTrailConditions } from '@/components/TrailConditionsProvider';
+import {
+  type ConditionReport,
+  conditionAgeLabel,
+  isConditionFresh,
+} from '@/data/trail-conditions';
+import { MAP_EVENTS } from '@/events';
+import { cn } from '@/lib/utils';
+import { ConditionBadge } from './ConditionBadge';
+
+const LINK_CLASS =
+  'bg-transparent border-none p-0 cursor-pointer text-[10px] text-blue-600 hover:underline shrink-0';
+
+export function TrailConditionsStrip({
+  slug,
+  trailName,
+}: {
+  slug: string;
+  trailName: string;
+}) {
+  const { latest, lockedReason: reasonFor, options } = useTrailConditions();
+  const [expanded, setExpanded] = useState(false);
+  const [history, setHistory] = useState<ConditionReport[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  // Which trail the loaded history belongs to, so switching trails can't leave
+  // one trail's reports under another's name.
+  const loadedFor = useRef<string | null>(null);
+
+  const current = latest[slug];
+
+  // Collapse when the pane moves on, or the previous trail's history shows
+  // until the refetch lands.
+  useEffect(() => {
+    setExpanded(false);
+    setHistory(null);
+    loadedFor.current = null;
+  }, [slug]);
+
+  useEffect(() => {
+    if (!expanded || loadedFor.current === slug) {
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+
+    // `async` so a synchronous throw is caught too, as in the provider.
+    async function load() {
+      try {
+        const response = await fetch(
+          `/api/map/conditions/${encodeURIComponent(slug)}?city=${activeCityId}`,
+          { signal: controller.signal },
+        );
+        const data: { reports: ConditionReport[] } | null = response?.ok
+          ? await response.json()
+          : null;
+        setHistory(data?.reports ?? []);
+        loadedFor.current = slug;
+        setLoading(false);
+      } catch (error) {
+        if ((error as Error)?.name !== 'AbortError') {
+          // "Nobody has reported this yet" beats an error on a small panel.
+          setHistory([]);
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => controller.abort();
+  }, [expanded, slug]);
+
+  const openReport = useCallback(() => {
+    window.dispatchEvent(
+      new CustomEvent(MAP_EVENTS.CONDITION_REPORT_OPEN, {
+        detail: { slug, trailName },
+      }),
+    );
+  }, [slug, trailName]);
+
+  // No vocabulary means no database, so nothing to show and nowhere to send.
+  if (options.length === 0) {
+    return null;
+  }
+
+  const stale = current && !isConditionFresh(current.observedAt);
+  const lockedReason = reasonFor(slug);
+
+  return (
+    <div className="text-[10px] text-gray-500 mb-1 -mt-0.5">
+      <div className="flex items-center gap-2">
+        {current ? (
+          <>
+            <ConditionBadge report={current} showAge />
+            {/* The badge hides a stale report, which would leave this row
+                looking like nobody had ever reported the trail. */}
+            {stale && (
+              <span className="truncate">
+                Last reported {conditionAgeLabel(current.observedAt)} —{' '}
+                {current.name.toLowerCase()}
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="truncate">No recent condition reports</span>
+        )}
+
+        <button
+          type="button"
+          className={cn(LINK_CLASS, 'ml-auto')}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          <FontAwesomeIcon
+            icon={expanded ? faChevronDown : faChevronRight}
+            className="mr-1"
+          />
+          History
+        </button>
+        {lockedReason === null ? (
+          <button type="button" className={LINK_CLASS} onClick={openReport}>
+            <FontAwesomeIcon icon={faPenToSquare} className="mr-1" />
+            Report
+          </button>
+        ) : (
+          /* The steward's sentence, where the button was. The badge and history
+             stay: closing the form does not unsay what was already reported. */
+          <span
+            className="flex items-center gap-1 shrink-0 max-w-[55%] text-gray-400"
+            title={lockedReason}
+          >
+            <FontAwesomeIcon icon={faLock} />
+            <span className="truncate">{lockedReason}</span>
+          </span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="mt-1 max-h-24 overflow-y-auto pr-1">
+          {loading && <div className="py-0.5">Loading…</div>}
+          {!loading && history?.length === 0 && (
+            <div className="py-0.5">
+              {/* Don't invite a report the trail won't take. */}
+              {lockedReason === null
+                ? 'Nothing reported yet. Ridden it lately?'
+                : 'Nothing reported.'}
+            </div>
+          )}
+          {!loading &&
+            history?.map((report) => (
+              <div
+                // Two reports can share a date, so the date alone isn't a key.
+                key={`${report.observedAt}-${report.value}-${report.source}`}
+                className="flex items-center gap-2 py-0.5"
+              >
+                <span
+                  className="shrink-0 w-2 h-2 rounded-full"
+                  style={{ backgroundColor: report.color }}
+                />
+                <span className="truncate">{report.name}</span>
+                <span className="ml-auto shrink-0 opacity-70">
+                  {conditionAgeLabel(report.observedAt)}
+                </span>
+              </div>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/TrailConditionsStrip.tsx
+++ b/src/components/sidebar/TrailConditionsStrip.tsx
@@ -21,7 +21,7 @@ import { useTrailConditions } from '@/components/TrailConditionsProvider';
 import {
   type ConditionReport,
   conditionAgeLabel,
-  isConditionFresh,
+  isConditionCurrent,
 } from '@/data/trail-conditions';
 import { MAP_EVENTS } from '@/events';
 import { cn } from '@/lib/utils';
@@ -103,7 +103,8 @@ export function TrailConditionsStrip({
     return null;
   }
 
-  const stale = current && !isConditionFresh(current.observedAt);
+  // A closure never goes stale, so this is never true for one.
+  const stale = current && !isConditionCurrent(current);
   const lockedReason = reasonFor(slug);
 
   return (

--- a/src/components/sidebar/index.ts
+++ b/src/components/sidebar/index.ts
@@ -11,6 +11,8 @@ export { BikeResourcesList } from './BikeResourcesList';
 export { BikeRentalList } from './BikeRentalList';
 export { InformationSection } from './InformationSection';
 export { SidebarCard } from './SidebarCard';
+export { ConditionBadge } from './ConditionBadge';
+export { TrailConditionsStrip } from './TrailConditionsStrip';
 
 // Types
 export type {

--- a/src/data/condition-vocabulary.ts
+++ b/src/data/condition-vocabulary.ts
@@ -14,16 +14,12 @@
  */
 export const CONDITION_FRESH_DAYS = 14;
 
-/**
- * How far back the summary query looks. Wider than the freshness cutoff so the
- * pane can still say "last reported 3 weeks ago".
- */
-export const CONDITION_SUMMARY_DAYS = 60;
-
 export interface ConditionSeed {
   /** The colour the badge pill is tinted with. */
   color: string;
   description?: string;
+  /** Draws the trail closed on the map, and stops the badge expiring. */
+  marksClosed?: boolean;
   name: string;
   /** Best-to-worst order. Drives the admin list and the report dropdown. */
   sortOrder: number;
@@ -80,6 +76,7 @@ export const DEFAULT_CONDITIONS: ConditionSeed[] = [
   {
     color: '#dc2626',
     description: 'Closed by the land manager, or blocked. Do not ride.',
+    marksClosed: true,
     name: 'Closed',
     sortOrder: 70,
     value: 'closed',

--- a/src/data/condition-vocabulary.ts
+++ b/src/data/condition-vocabulary.ts
@@ -1,0 +1,90 @@
+/**
+ * The default condition vocabulary, seeded by the migration and by the seed
+ * scripts. Curated in the admin after that.
+ *
+ * These stay in code because a report's condition is a required relationship —
+ * an empty table is one nobody can file a report against.
+ *
+ * Client-safe: no Node-only imports.
+ */
+
+/**
+ * How long a report keeps driving the badge. Past this it stays in history but
+ * stops being shown as the current answer.
+ */
+export const CONDITION_FRESH_DAYS = 14;
+
+/**
+ * How far back the summary query looks. Wider than the freshness cutoff so the
+ * pane can still say "last reported 3 weeks ago".
+ */
+export const CONDITION_SUMMARY_DAYS = 60;
+
+export interface ConditionSeed {
+  /** The colour the badge pill is tinted with. */
+  color: string;
+  description?: string;
+  name: string;
+  /** Best-to-worst order. Drives the admin list and the report dropdown. */
+  sortOrder: number;
+  /** The stable key matched on in code. */
+  value: string;
+}
+
+/** Ordered best to worst — this is the order of the rider's dropdown. */
+export const DEFAULT_CONDITIONS: ConditionSeed[] = [
+  {
+    color: '#059669',
+    description: 'Damp, grippy dirt. As good as it gets.',
+    name: 'Prime / tacky',
+    sortOrder: 10,
+    value: 'tacky',
+  },
+  {
+    color: '#16a34a',
+    description: 'Dry and fast, no surprises.',
+    name: 'Dry',
+    sortOrder: 20,
+    value: 'dry',
+  },
+  {
+    color: '#ca8a04',
+    description:
+      'Dry to the point of loose corners and blown-out braking bumps.',
+    name: 'Dusty / loose',
+    sortOrder: 30,
+    value: 'dusty',
+  },
+  {
+    color: '#2563eb',
+    description: 'Wet but holding up — rideable without damaging the tread.',
+    name: 'Wet',
+    sortOrder: 40,
+    value: 'wet',
+  },
+  {
+    color: '#b45309',
+    description: 'Soft enough to rut. Please stay off until it dries.',
+    name: 'Muddy — stay off',
+    sortOrder: 50,
+    value: 'muddy',
+  },
+  {
+    color: '#0ea5e9',
+    description:
+      'Snow-covered or frozen. Fine when frozen hard, ruinous when soft.',
+    name: 'Snow / ice',
+    sortOrder: 60,
+    value: 'snow',
+  },
+  {
+    color: '#dc2626',
+    description: 'Closed by the land manager, or blocked. Do not ride.',
+    name: 'Closed',
+    sortOrder: 70,
+    value: 'closed',
+  },
+];
+
+/** The colour a condition falls back to if a curator has blanked its own. */
+export const DEFAULT_CONDITION_COLOR = '#6b7280';

--- a/src/data/mountain-bike-trails.ts
+++ b/src/data/mountain-bike-trails.ts
@@ -40,7 +40,9 @@ export interface MountainBikeTrail {
   osmIds?: number[];
 }
 
-export function slugForTrail(trail: MountainBikeTrail): string {
+export function slugForTrail(
+  trail: Pick<MountainBikeTrail, 'slug' | 'trailName'>,
+): string {
   return trail.slug ?? slugify(trail.trailName);
 }
 

--- a/src/data/trail-conditions.test.ts
+++ b/src/data/trail-conditions.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { CONDITION_FRESH_DAYS } from './condition-vocabulary';
+import {
+  conditionAgeDays,
+  conditionAgeLabel,
+  DEFAULT_LOCK_MESSAGE,
+  isConditionFresh,
+  lockFor,
+  resolveLockMessage,
+} from './trail-conditions';
+
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+
+function daysBefore(days: number, hours = 0): string {
+  const date = new Date(NOW);
+  date.setDate(date.getDate() - days);
+  date.setHours(date.getHours() - hours);
+  return date.toISOString();
+}
+
+describe('conditionAgeDays', () => {
+  it('floors rather than rounds', () => {
+    // 20 hours ago is still "today" — rounding would call it a day old as soon
+    // as the clock crossed the halfway mark, which reads as older than it is.
+    expect(conditionAgeDays(daysBefore(0, 20), NOW)).toBe(0);
+    expect(conditionAgeDays(daysBefore(1, 1), NOW)).toBe(1);
+  });
+
+  it('never goes negative for a report dated slightly ahead', () => {
+    const ahead = new Date(NOW);
+    ahead.setHours(ahead.getHours() + 6);
+    expect(conditionAgeDays(ahead.toISOString(), NOW)).toBe(0);
+  });
+
+  it('treats an unreadable date as infinitely old', () => {
+    expect(conditionAgeDays('not a date', NOW)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe('isConditionFresh', () => {
+  it('is fresh right up to the cutoff and stale on it', () => {
+    expect(isConditionFresh(daysBefore(CONDITION_FRESH_DAYS - 1), NOW)).toBe(
+      true,
+    );
+    expect(isConditionFresh(daysBefore(CONDITION_FRESH_DAYS), NOW)).toBe(false);
+  });
+
+  it('is stale for the October-report-in-March case', () => {
+    expect(isConditionFresh(daysBefore(150), NOW)).toBe(false);
+  });
+
+  it('treats an unreadable date as stale rather than fresh', () => {
+    // Wrong in the safe direction: a badge that fails to appear beats one that
+    // confidently states a condition nobody can date.
+    expect(isConditionFresh('', NOW)).toBe(false);
+  });
+});
+
+describe('conditionAgeLabel', () => {
+  it('names the recent days', () => {
+    expect(conditionAgeLabel(daysBefore(0), NOW)).toBe('today');
+    expect(conditionAgeLabel(daysBefore(1), NOW)).toBe('yesterday');
+    expect(conditionAgeLabel(daysBefore(3), NOW)).toBe('3 days ago');
+    expect(conditionAgeLabel(daysBefore(13), NOW)).toBe('13 days ago');
+  });
+
+  it('switches to weeks, then months', () => {
+    expect(conditionAgeLabel(daysBefore(14), NOW)).toBe('2 weeks ago');
+    expect(conditionAgeLabel(daysBefore(59), NOW)).toBe('8 weeks ago');
+    expect(conditionAgeLabel(daysBefore(60), NOW)).toBe('2 months ago');
+  });
+
+  it('never says "1 months ago"', () => {
+    // The whole point of the 60-day cutover. Walk the boundary rather than
+    // trusting the arithmetic by eye.
+    for (let days = 60; days < 400; days++) {
+      expect(conditionAgeLabel(daysBefore(days), NOW)).not.toBe('1 months ago');
+    }
+  });
+
+  it('degrades rather than printing NaN', () => {
+    expect(conditionAgeLabel('nonsense', NOW)).toBe('at some point');
+  });
+});
+
+describe('resolveLockMessage', () => {
+  it('takes the first thing anyone actually wrote', () => {
+    expect(resolveLockMessage('trail note', 'complex note')).toBe('trail note');
+    expect(resolveLockMessage(null, 'complex note')).toBe('complex note');
+  });
+
+  it('treats blank and whitespace-only as having said nothing', () => {
+    // A curator who ticks the box and leaves the note empty means "no comment",
+    // not "show an empty line".
+    expect(resolveLockMessage('', '   ', 'site note')).toBe('site note');
+    expect(resolveLockMessage(undefined, null)).toBe(DEFAULT_LOCK_MESSAGE);
+  });
+
+  it('trims what it returns', () => {
+    expect(resolveLockMessage('  Closed for logging.  ')).toBe(
+      'Closed for logging.',
+    );
+  });
+});
+
+describe('lockFor', () => {
+  const open = { locked: {}, reporting: { enabled: true, message: '' } };
+
+  it('is open when nothing says otherwise', () => {
+    expect(lockFor(open, 'pondo')).toBeNull();
+  });
+
+  it('closes one trail without touching the others', () => {
+    const summary = { ...open, locked: { pondo: 'Closed for logging.' } };
+
+    expect(lockFor(summary, 'pondo')).toBe('Closed for logging.');
+    expect(lockFor(summary, 'homestead')).toBeNull();
+  });
+
+  it('falls back to the default when a locked trail has no note', () => {
+    expect(lockFor({ ...open, locked: { pondo: '' } }, 'pondo')).toBe(
+      DEFAULT_LOCK_MESSAGE,
+    );
+  });
+
+  it('site-wide off closes every trail, named or not', () => {
+    const summary = {
+      locked: {},
+      reporting: { enabled: false, message: 'Use the forum instead.' },
+    };
+
+    expect(lockFor(summary, 'pondo')).toBe('Use the forum instead.');
+    expect(lockFor(summary, 'anything-at-all')).toBe('Use the forum instead.');
+  });
+
+  it('site-wide off outranks a per-trail note', () => {
+    // Precedence has to match what the server enforces on submit, or the button
+    // and the refusal would give different reasons.
+    const summary = {
+      locked: { pondo: 'Closed for logging.' },
+      reporting: { enabled: false, message: 'Reporting is off for now.' },
+    };
+
+    expect(lockFor(summary, 'pondo')).toBe('Reporting is off for now.');
+  });
+
+  it('site-wide off with no message still explains itself', () => {
+    const summary = { locked: {}, reporting: { enabled: false, message: '' } };
+
+    expect(lockFor(summary, 'pondo')).toBe(DEFAULT_LOCK_MESSAGE);
+  });
+});

--- a/src/data/trail-conditions.test.ts
+++ b/src/data/trail-conditions.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { CONDITION_FRESH_DAYS } from './condition-vocabulary';
+import type { ConditionReport } from './trail-conditions';
 import {
+  closedTrails,
   conditionAgeDays,
   conditionAgeLabel,
   DEFAULT_LOCK_MESSAGE,
+  isConditionCurrent,
   isConditionFresh,
+  isTrailClosed,
   lockFor,
   resolveLockMessage,
 } from './trail-conditions';
@@ -148,5 +152,67 @@ describe('lockFor', () => {
     const summary = { locked: {}, reporting: { enabled: false, message: '' } };
 
     expect(lockFor(summary, 'pondo')).toBe(DEFAULT_LOCK_MESSAGE);
+  });
+});
+
+describe('closures', () => {
+  function report(daysAgo: number, marksClosed: boolean): ConditionReport {
+    const observed = new Date(NOW);
+    observed.setDate(observed.getDate() - daysAgo);
+    return {
+      color: '#dc2626',
+      marksClosed,
+      name: marksClosed ? 'Closed' : 'Dry',
+      observedAt: observed.toISOString(),
+      source: 'public',
+      value: marksClosed ? 'closed' : 'dry',
+    };
+  }
+
+  it('a closure never goes stale', () => {
+    // The whole point: a trail does not quietly reopen because nobody has
+    // ridden it lately.
+    expect(isConditionCurrent(report(400, true), NOW)).toBe(true);
+    expect(isConditionCurrent(report(400, false), NOW)).toBe(false);
+  });
+
+  it('everything else still fades at the cutoff', () => {
+    expect(isConditionCurrent(report(1, false), NOW)).toBe(true);
+    expect(isConditionCurrent(report(CONDITION_FRESH_DAYS, false), NOW)).toBe(
+      false,
+    );
+  });
+
+  it('a trail is closed only while a closure is its newest report', () => {
+    expect(isTrailClosed({ latest: { pondo: report(3, true) } }, 'pondo')).toBe(
+      true,
+    );
+    // Reopened: the newest report is not a closure, so the trail is not closed.
+    expect(
+      isTrailClosed({ latest: { pondo: report(1, false) } }, 'pondo'),
+    ).toBe(false);
+    expect(isTrailClosed({ latest: {} }, 'pondo')).toBe(false);
+  });
+
+  it('picks out the closed trails, keyed by slug', () => {
+    const trails = [
+      { slug: 'pondo', trailName: 'Pondo' },
+      { slug: 'rattler', trailName: 'Rattler' },
+    ];
+    const summary = {
+      latest: { pondo: report(200, true), rattler: report(2, false) },
+    };
+
+    expect(closedTrails(summary, trails).map((t) => t.trailName)).toEqual([
+      'Pondo',
+    ]);
+  });
+
+  it('falls back to a derived slug when the trail carries none', () => {
+    // Checked-in trails have no `slug`; slugForTrail derives one, and the
+    // lookup has to use the same key the API does.
+    const summary = { latest: { 'bear-creek': report(1, true) } };
+
+    expect(closedTrails(summary, [{ trailName: 'Bear Creek' }]).length).toBe(1);
   });
 });

--- a/src/data/trail-conditions.ts
+++ b/src/data/trail-conditions.ts
@@ -1,0 +1,138 @@
+/**
+ * The shape trail conditions travel in, plus the rules about their age and
+ * whether a trail is taking reports.
+ *
+ * Shared by the server and the client, so no Node-only imports.
+ */
+import { CONDITION_FRESH_DAYS } from './condition-vocabulary';
+
+/** One option on the report form, out of the curated vocabulary. */
+export interface ConditionOption {
+  color: string;
+  description?: string;
+  name: string;
+  /** The stable key. Match on this, never on `name`. */
+  value: string;
+}
+
+/** One report, as the map shows it. */
+export interface ConditionReport {
+  color: string;
+  name: string;
+  /** ISO 8601. When the trail was ridden, not when this was submitted. */
+  observedAt: string;
+  /** `admin` means the trail steward said so, rather than a rider guessing. */
+  source: 'admin' | 'public';
+  value: string;
+}
+
+/** Shown where the Report button was, when nobody wrote a note. */
+export const DEFAULT_LOCK_MESSAGE = 'This trail is not taking new reports.';
+
+/** What `/api/map/conditions` answers with. */
+export interface ConditionSummary {
+  /** The newest visible report per trail slug. Trails with none are absent. */
+  latest: Record<string, ConditionReport>;
+  /**
+   * Closed trails, keyed by slug, with the note already resolved through
+   * trail → complex by the server. Absent means open, so this stays small.
+   */
+  locked: Record<string, string>;
+  options: ConditionOption[];
+  /** The site-wide switch, so a global closure needn't name every slug. */
+  reporting: { enabled: boolean; message: string };
+}
+
+/**
+ * The first note anyone actually wrote, or the default. Pass them most-specific
+ * first. Blank and whitespace-only both count as having said nothing.
+ */
+export function resolveLockMessage(
+  ...notes: (string | null | undefined)[]
+): string {
+  for (const note of notes) {
+    const trimmed = note?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return DEFAULT_LOCK_MESSAGE;
+}
+
+/**
+ * Whether a trail takes reports, and what to say if not. The one place the three
+ * switches are combined, so the button and the server's refusal agree. Any one
+ * being off is enough; site-wide outranks a per-trail note.
+ */
+export function lockFor(
+  summary: Pick<ConditionSummary, 'locked' | 'reporting'>,
+  slug: string,
+): null | string {
+  if (!summary.reporting.enabled) {
+    return summary.reporting.message || DEFAULT_LOCK_MESSAGE;
+  }
+  const message = summary.locked[slug];
+  if (message === undefined) {
+    return null;
+  }
+  return message || DEFAULT_LOCK_MESSAGE;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Whole days since a report, floored so "1 day ago" means a full day passed.
+ * Rounding would age a four-hour-old report the moment the clock crossed noon.
+ */
+export function conditionAgeDays(
+  observedAt: string,
+  now: Date = new Date(),
+): number {
+  const then = new Date(observedAt).getTime();
+  if (Number.isNaN(then)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(0, Math.floor((now.getTime() - then) / MS_PER_DAY));
+}
+
+/**
+ * Whether a report is recent enough to show as the current answer. The whole
+ * staleness policy, in one place because the badge and the pane must agree.
+ * Past the cutoff it stays in history but stops being the badge — a "Dry" pill
+ * from October would be confidently wrong in March.
+ */
+export function isConditionFresh(
+  observedAt: string,
+  now: Date = new Date(),
+): boolean {
+  return conditionAgeDays(observedAt, now) < CONDITION_FRESH_DAYS;
+}
+
+/**
+ * A human age — "today", "3 days ago", "2 weeks ago". Hand-rolled: this repo has
+ * no date library, and `Intl.RelativeTimeFormat` still needs the unit choosing.
+ */
+export function conditionAgeLabel(
+  observedAt: string,
+  now: Date = new Date(),
+): string {
+  const days = conditionAgeDays(observedAt, now);
+
+  if (!Number.isFinite(days)) {
+    return 'at some point';
+  }
+  if (days === 0) {
+    return 'today';
+  }
+  if (days === 1) {
+    return 'yesterday';
+  }
+  if (days < 14) {
+    return `${days} days ago`;
+  }
+  if (days < 60) {
+    return `${Math.floor(days / 7)} weeks ago`;
+  }
+  // 60 rather than 30 so this never says "1 months ago".
+  return `${Math.floor(days / 30)} months ago`;
+}

--- a/src/data/trail-conditions.ts
+++ b/src/data/trail-conditions.ts
@@ -5,6 +5,7 @@
  * Shared by the server and the client, so no Node-only imports.
  */
 import { CONDITION_FRESH_DAYS } from './condition-vocabulary';
+import { slugForTrail } from './mountain-bike-trails';
 
 /** One option on the report form, out of the curated vocabulary. */
 export interface ConditionOption {
@@ -18,6 +19,12 @@ export interface ConditionOption {
 /** One report, as the map shows it. */
 export interface ConditionReport {
   color: string;
+  /**
+   * This condition means the trail is shut. Set on the condition type, not the
+   * report, so a curator decides which grades count — the app never matches on
+   * the value 'closed'.
+   */
+  marksClosed: boolean;
   name: string;
   /** ISO 8601. When the trail was ridden, not when this was submitted. */
   observedAt: string;
@@ -106,6 +113,43 @@ export function isConditionFresh(
   now: Date = new Date(),
 ): boolean {
   return conditionAgeDays(observedAt, now) < CONDITION_FRESH_DAYS;
+}
+
+/**
+ * Whether a report still stands.
+ *
+ * Everything fades after a fortnight except a closure, which holds until
+ * somebody reports something else. A closure is a state, not an observation — a
+ * trail does not quietly reopen because nobody has ridden it lately, and
+ * expiring one would take a barrier off the map on a timer.
+ */
+export function isConditionCurrent(
+  report: ConditionReport,
+  now: Date = new Date(),
+): boolean {
+  return report.marksClosed || isConditionFresh(report.observedAt, now);
+}
+
+/** Whether this trail's newest report says it is shut. */
+export function isTrailClosed(
+  summary: Pick<ConditionSummary, 'latest'>,
+  slug: string,
+): boolean {
+  return summary.latest[slug]?.marksClosed === true;
+}
+
+/**
+ * The trails whose newest report says they are shut.
+ *
+ * Conditions are keyed by slug, but the map layers join on the trail name (or
+ * on OSM way ids) — so the two are reconciled here, once, rather than in the
+ * map code.
+ */
+export function closedTrails<T extends { slug?: string; trailName: string }>(
+  summary: Pick<ConditionSummary, 'latest'>,
+  trails: T[],
+): T[] {
+  return trails.filter((trail) => isTrailClosed(summary, slugForTrail(trail)));
 }
 
 /**

--- a/src/events.ts
+++ b/src/events.ts
@@ -20,6 +20,10 @@ export const MAP_EVENTS = {
   RIDE_SELECT: 'ride-select',
   RIDE_DESELECT: 'ride-deselect',
   RIDES_PANEL_TOGGLE: 'rides-panel-toggle',
+  // Asks for the "report conditions" form, carrying { trailName }. The form is
+  // an event rather than a prop so the one modal at the page root serves every
+  // place that might offer it — today the elevation pane, tomorrow wherever.
+  CONDITION_REPORT_OPEN: 'condition-report-open',
   TOAST: 'toast',
   MAP_READY: 'map-ready',
 } as const;

--- a/src/migrations/20260807_202004_trail_conditions.json
+++ b/src/migrations/20260807_202004_trail_conditions.json
@@ -1,0 +1,2887 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trails_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_id": {
+          "name": "rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind_id": {
+          "name": "kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geom": {
+          "name": "geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_ids": {
+          "name": "osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebuild_geometry": {
+          "name": "rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "osm_report": {
+          "name": "osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_gain": {
+          "name": "elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_loss": {
+          "name": "elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_min": {
+          "name": "elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_max": {
+          "name": "elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_profile": {
+          "name": "elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_source": {
+          "name": "geometry_source",
+          "type": "enum_trails_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_trails_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "trails_trail_name_idx": {
+          "name": "trails_trail_name_idx",
+          "columns": [
+            {
+              "expression": "trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_area_idx": {
+          "name": "trails_area_idx",
+          "columns": [
+            {
+              "expression": "area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_organization_idx": {
+          "name": "trails_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_rating_idx": {
+          "name": "trails_rating_idx",
+          "columns": [
+            {
+              "expression": "rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_kind_idx": {
+          "name": "trails_kind_idx",
+          "columns": [
+            {
+              "expression": "kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_slug_idx": {
+          "name": "trails_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_updated_at_idx": {
+          "name": "trails_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_created_at_idx": {
+          "name": "trails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails__status_idx": {
+          "name": "trails__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trails_area_id_trail_areas_id_fk": {
+          "name": "trails_area_id_trail_areas_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_organization_id_organizations_id_fk": {
+          "name": "trails_organization_id_organizations_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_rating_id_trail_ratings_id_fk": {
+          "name": "trails_rating_id_trail_ratings_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_kind_id_trail_kinds_id_fk": {
+          "name": "trails_kind_id_trail_kinds_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._trails_v": {
+      "name": "_trails_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_trail_name": {
+          "name": "version_trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_city": {
+          "name": "version_city",
+          "type": "enum__trails_v_version_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "version_area_id": {
+          "name": "version_area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_organization_id": {
+          "name": "version_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rating_id": {
+          "name": "version_rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_kind_id": {
+          "name": "version_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_display_name": {
+          "name": "version_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geom": {
+          "name": "version_geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_osm_ids": {
+          "name": "version_osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rebuild_geometry": {
+          "name": "version_rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_osm_report": {
+          "name": "version_osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_distance": {
+          "name": "version_distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_gain": {
+          "name": "version_elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_loss": {
+          "name": "version_elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_min": {
+          "name": "version_elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_max": {
+          "name": "version_elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_bounds": {
+          "name": "version_bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_profile": {
+          "name": "version_elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geometry_source": {
+          "name": "version_geometry_source",
+          "type": "enum__trails_v_version_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__trails_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_trails_v_parent_idx": {
+          "name": "_trails_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_trail_name_idx": {
+          "name": "_trails_v_version_version_trail_name_idx",
+          "columns": [
+            {
+              "expression": "version_trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_area_idx": {
+          "name": "_trails_v_version_version_area_idx",
+          "columns": [
+            {
+              "expression": "version_area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_organization_idx": {
+          "name": "_trails_v_version_version_organization_idx",
+          "columns": [
+            {
+              "expression": "version_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_rating_idx": {
+          "name": "_trails_v_version_version_rating_idx",
+          "columns": [
+            {
+              "expression": "version_rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_kind_idx": {
+          "name": "_trails_v_version_version_kind_idx",
+          "columns": [
+            {
+              "expression": "version_kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_slug_idx": {
+          "name": "_trails_v_version_version_slug_idx",
+          "columns": [
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_updated_at_idx": {
+          "name": "_trails_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_created_at_idx": {
+          "name": "_trails_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version__status_idx": {
+          "name": "_trails_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_created_at_idx": {
+          "name": "_trails_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_updated_at_idx": {
+          "name": "_trails_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_latest_idx": {
+          "name": "_trails_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_trails_v_parent_id_trails_id_fk": {
+          "name": "_trails_v_parent_id_trails_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_area_id_trail_areas_id_fk": {
+          "name": "_trails_v_version_area_id_trail_areas_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "version_area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_organization_id_organizations_id_fk": {
+          "name": "_trails_v_version_organization_id_organizations_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "version_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_rating_id_trail_ratings_id_fk": {
+          "name": "_trails_v_version_rating_id_trail_ratings_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "version_rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_kind_id_trail_kinds_id_fk": {
+          "name": "_trails_v_version_kind_id_trail_kinds_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "version_kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_conditions": {
+      "name": "trail_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_trail_conditions_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_conditions_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "reporter_hash": {
+          "name": "reporter_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_conditions_trail_idx": {
+          "name": "trail_conditions_trail_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_condition_idx": {
+          "name": "trail_conditions_condition_idx",
+          "columns": [
+            {
+              "expression": "condition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_observed_at_idx": {
+          "name": "trail_conditions_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_hidden_idx": {
+          "name": "trail_conditions_hidden_idx",
+          "columns": [
+            {
+              "expression": "hidden",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_reporter_hash_idx": {
+          "name": "trail_conditions_reporter_hash_idx",
+          "columns": [
+            {
+              "expression": "reporter_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_updated_at_idx": {
+          "name": "trail_conditions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_created_at_idx": {
+          "name": "trail_conditions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_conditions_trail_id_trails_id_fk": {
+          "name": "trail_conditions_trail_id_trails_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trail_conditions_condition_id_trail_condition_types_id_fk": {
+          "name": "trail_conditions_condition_id_trail_condition_types_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_areas": {
+      "name": "trail_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_areas_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_areas_name_idx": {
+          "name": "trail_areas_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_region_idx": {
+          "name": "trail_areas_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_updated_at_idx": {
+          "name": "trail_areas_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_created_at_idx": {
+          "name": "trail_areas_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_ratings": {
+      "name": "trail_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_ratings_name_idx": {
+          "name": "trail_ratings_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_value_idx": {
+          "name": "trail_ratings_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_updated_at_idx": {
+          "name": "trail_ratings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_created_at_idx": {
+          "name": "trail_ratings_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_kinds": {
+      "name": "trail_kinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "enum_trail_kinds_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mountain'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_kinds_name_idx": {
+          "name": "trail_kinds_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_value_idx": {
+          "name": "trail_kinds_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_updated_at_idx": {
+          "name": "trail_kinds_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_created_at_idx": {
+          "name": "trail_kinds_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_condition_types": {
+      "name": "trail_condition_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_condition_types_name_idx": {
+          "name": "trail_condition_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_value_idx": {
+          "name": "trail_condition_types_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_updated_at_idx": {
+          "name": "trail_condition_types_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_created_at_idx": {
+          "name": "trail_condition_types_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_organizations_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_name_idx": {
+          "name": "organizations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_updated_at_idx": {
+          "name": "organizations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_created_at_idx": {
+          "name": "organizations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_users_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trails_id": {
+          "name": "trails_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_conditions_id": {
+          "name": "trail_conditions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_areas_id": {
+          "name": "trail_areas_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_ratings_id": {
+          "name": "trail_ratings_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_kinds_id": {
+          "name": "trail_kinds_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_condition_types_id": {
+          "name": "trail_condition_types_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizations_id": {
+          "name": "organizations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trails_id_idx": {
+          "name": "payload_locked_documents_rels_trails_id_idx",
+          "columns": [
+            {
+              "expression": "trails_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_conditions_id_idx": {
+          "name": "payload_locked_documents_rels_trail_conditions_id_idx",
+          "columns": [
+            {
+              "expression": "trail_conditions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_areas_id_idx": {
+          "name": "payload_locked_documents_rels_trail_areas_id_idx",
+          "columns": [
+            {
+              "expression": "trail_areas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_ratings_id_idx": {
+          "name": "payload_locked_documents_rels_trail_ratings_id_idx",
+          "columns": [
+            {
+              "expression": "trail_ratings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_kinds_id_idx": {
+          "name": "payload_locked_documents_rels_trail_kinds_id_idx",
+          "columns": [
+            {
+              "expression": "trail_kinds_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_condition_types_id_idx": {
+          "name": "payload_locked_documents_rels_trail_condition_types_id_idx",
+          "columns": [
+            {
+              "expression": "trail_condition_types_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_organizations_id_idx": {
+          "name": "payload_locked_documents_rels_organizations_id_idx",
+          "columns": [
+            {
+              "expression": "organizations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trails_fk": {
+          "name": "payload_locked_documents_rels_trails_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trails_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_conditions_fk": {
+          "name": "payload_locked_documents_rels_trail_conditions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_conditions",
+          "columnsFrom": [
+            "trail_conditions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_areas_fk": {
+          "name": "payload_locked_documents_rels_trail_areas_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "trail_areas_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_ratings_fk": {
+          "name": "payload_locked_documents_rels_trail_ratings_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "trail_ratings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_kinds_fk": {
+          "name": "payload_locked_documents_rels_trail_kinds_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "trail_kinds_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_condition_types_fk": {
+          "name": "payload_locked_documents_rels_trail_condition_types_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "trail_condition_types_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_organizations_fk": {
+          "name": "payload_locked_documents_rels_organizations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organizations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deep_color": {
+          "name": "deep_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neutral_tint": {
+          "name": "neutral_tint",
+          "type": "enum_theme_neutral_tint",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corner_style": {
+          "name": "corner_style",
+          "type": "enum_theme_corner_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "enum_theme_font_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_trails_city": {
+      "name": "enum_trails_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trails_geometry_source": {
+      "name": "enum_trails_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum_trails_status": {
+      "name": "enum_trails_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__trails_v_version_city": {
+      "name": "enum__trails_v_version_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum__trails_v_version_geometry_source": {
+      "name": "enum__trails_v_version_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum__trails_v_version_status": {
+      "name": "enum__trails_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum_trail_conditions_source": {
+      "name": "enum_trail_conditions_source",
+      "schema": "public",
+      "values": [
+        "public",
+        "admin"
+      ]
+    },
+    "public.enum_trail_conditions_city": {
+      "name": "enum_trail_conditions_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_areas_city": {
+      "name": "enum_trail_areas_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_kinds_icon": {
+      "name": "enum_trail_kinds_icon",
+      "schema": "public",
+      "values": [
+        "mountain",
+        "route"
+      ]
+    },
+    "public.enum_organizations_city": {
+      "name": "enum_organizations_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin"
+      ]
+    },
+    "public.enum_users_city": {
+      "name": "enum_users_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_theme_neutral_tint": {
+      "name": "enum_theme_neutral_tint",
+      "schema": "public",
+      "values": [
+        "cool",
+        "neutral",
+        "warm"
+      ]
+    },
+    "public.enum_theme_corner_style": {
+      "name": "enum_theme_corner_style",
+      "schema": "public",
+      "values": [
+        "sharp",
+        "soft",
+        "round"
+      ]
+    },
+    "public.enum_theme_font_family": {
+      "name": "enum_theme_font_family",
+      "schema": "public",
+      "values": [
+        "geist",
+        "system",
+        "serif"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "7ebaeb0c-8813-4769-bd53-bebe18921201",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260807_202004_trail_conditions.ts
+++ b/src/migrations/20260807_202004_trail_conditions.ts
@@ -1,0 +1,95 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Trail conditions: `trail_condition_types` (the dropdown) and
+ * `trail_conditions` (the reports).
+ *
+ * The SQL is exactly as Payload generated it, so a later `migrate:create` sees
+ * no drift. Two things to know:
+ *
+ * - `trail_id` is NOT NULL with an ON DELETE SET NULL foreign key, so Postgres
+ *   refuses to delete a trail that has reports. `Trails` has a `beforeDelete`
+ *   hook that clears them first; a not-null violation here means it broke.
+ * - The seed is a separate `db.execute`, like the rating/kind seed in the
+ *   initial migration: `condition_id` is required, so no rows means no form.
+ */
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_trail_conditions_source" AS ENUM('public', 'admin');
+  CREATE TYPE "public"."enum_trail_conditions_city" AS ENUM('chattanooga', 'bend');
+  CREATE TABLE "trail_conditions" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"trail_id" integer NOT NULL,
+  	"condition_id" integer NOT NULL,
+  	"observed_at" timestamp(3) with time zone NOT NULL,
+  	"source" "enum_trail_conditions_source" DEFAULT 'public' NOT NULL,
+  	"hidden" boolean DEFAULT false,
+  	"city" "enum_trail_conditions_city" DEFAULT 'bend' NOT NULL,
+  	"reporter_hash" varchar,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  CREATE TABLE "trail_condition_types" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"name" varchar NOT NULL,
+  	"value" varchar NOT NULL,
+  	"color" varchar DEFAULT '#6b7280' NOT NULL,
+  	"sort_order" numeric DEFAULT 50 NOT NULL,
+  	"active" boolean DEFAULT true,
+  	"description" varchar,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "trail_conditions_id" integer;
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "trail_condition_types_id" integer;
+  ALTER TABLE "trail_conditions" ADD CONSTRAINT "trail_conditions_trail_id_trails_id_fk" FOREIGN KEY ("trail_id") REFERENCES "public"."trails"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "trail_conditions" ADD CONSTRAINT "trail_conditions_condition_id_trail_condition_types_id_fk" FOREIGN KEY ("condition_id") REFERENCES "public"."trail_condition_types"("id") ON DELETE set null ON UPDATE no action;
+  CREATE INDEX "trail_conditions_trail_idx" ON "trail_conditions" USING btree ("trail_id");
+  CREATE INDEX "trail_conditions_condition_idx" ON "trail_conditions" USING btree ("condition_id");
+  CREATE INDEX "trail_conditions_observed_at_idx" ON "trail_conditions" USING btree ("observed_at");
+  CREATE INDEX "trail_conditions_hidden_idx" ON "trail_conditions" USING btree ("hidden");
+  CREATE INDEX "trail_conditions_reporter_hash_idx" ON "trail_conditions" USING btree ("reporter_hash");
+  CREATE INDEX "trail_conditions_updated_at_idx" ON "trail_conditions" USING btree ("updated_at");
+  CREATE INDEX "trail_conditions_created_at_idx" ON "trail_conditions" USING btree ("created_at");
+  CREATE UNIQUE INDEX "trail_condition_types_name_idx" ON "trail_condition_types" USING btree ("name");
+  CREATE UNIQUE INDEX "trail_condition_types_value_idx" ON "trail_condition_types" USING btree ("value");
+  CREATE INDEX "trail_condition_types_updated_at_idx" ON "trail_condition_types" USING btree ("updated_at");
+  CREATE INDEX "trail_condition_types_created_at_idx" ON "trail_condition_types" USING btree ("created_at");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_trail_conditions_fk" FOREIGN KEY ("trail_conditions_id") REFERENCES "public"."trail_conditions"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_trail_condition_types_fk" FOREIGN KEY ("trail_condition_types_id") REFERENCES "public"."trail_condition_types"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_trail_conditions_id_idx" ON "payload_locked_documents_rels" USING btree ("trail_conditions_id");
+  CREATE INDEX "payload_locked_documents_rels_trail_condition_types_id_idx" ON "payload_locked_documents_rels" USING btree ("trail_condition_types_id");`)
+
+  // Mirrors `src/data/condition-vocabulary.ts`; keep them in step. ON CONFLICT
+  // so a rerun is harmless and a curator's recolouring survives.
+  await db.execute(sql`
+  INSERT INTO "trail_condition_types" ("name", "value", "color", "sort_order", "active", "description") VALUES
+    ('Prime / tacky',    'tacky',  '#059669', 10, true, 'Damp, grippy dirt. As good as it gets.'),
+    ('Dry',              'dry',    '#16a34a', 20, true, 'Dry and fast, no surprises.'),
+    ('Dusty / loose',    'dusty',  '#ca8a04', 30, true, 'Dry to the point of loose corners and blown-out braking bumps.'),
+    ('Wet',              'wet',    '#2563eb', 40, true, 'Wet but holding up — rideable without damaging the tread.'),
+    ('Muddy — stay off', 'muddy',  '#b45309', 50, true, 'Soft enough to rut. Please stay off until it dries.'),
+    ('Snow / ice',       'snow',   '#0ea5e9', 60, true, 'Snow-covered or frozen. Fine when frozen hard, ruinous when soft.'),
+    ('Closed',           'closed', '#dc2626', 70, true, 'Closed by the land manager, or blocked. Do not ride.')
+  ON CONFLICT ("value") DO NOTHING;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "trail_conditions" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "trail_condition_types" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "trail_conditions" CASCADE;
+  DROP TABLE "trail_condition_types" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_trail_conditions_fk";
+  
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_trail_condition_types_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_trail_conditions_id_idx";
+  DROP INDEX "payload_locked_documents_rels_trail_condition_types_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "trail_conditions_id";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "trail_condition_types_id";
+  DROP TYPE "public"."enum_trail_conditions_source";
+  DROP TYPE "public"."enum_trail_conditions_city";`)
+}

--- a/src/migrations/20260807_213812_condition_report_locks.json
+++ b/src/migrations/20260807_213812_condition_report_locks.json
@@ -1,0 +1,3015 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trails_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_id": {
+          "name": "rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind_id": {
+          "name": "kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_reports_closed": {
+          "name": "condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "condition_reports_note": {
+          "name": "condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geom": {
+          "name": "geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_ids": {
+          "name": "osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebuild_geometry": {
+          "name": "rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "osm_report": {
+          "name": "osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_gain": {
+          "name": "elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_loss": {
+          "name": "elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_min": {
+          "name": "elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_max": {
+          "name": "elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_profile": {
+          "name": "elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_source": {
+          "name": "geometry_source",
+          "type": "enum_trails_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_trails_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "trails_trail_name_idx": {
+          "name": "trails_trail_name_idx",
+          "columns": [
+            {
+              "expression": "trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_area_idx": {
+          "name": "trails_area_idx",
+          "columns": [
+            {
+              "expression": "area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_organization_idx": {
+          "name": "trails_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_rating_idx": {
+          "name": "trails_rating_idx",
+          "columns": [
+            {
+              "expression": "rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_kind_idx": {
+          "name": "trails_kind_idx",
+          "columns": [
+            {
+              "expression": "kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_condition_reports_closed_idx": {
+          "name": "trails_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_slug_idx": {
+          "name": "trails_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_updated_at_idx": {
+          "name": "trails_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_created_at_idx": {
+          "name": "trails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails__status_idx": {
+          "name": "trails__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trails_area_id_trail_areas_id_fk": {
+          "name": "trails_area_id_trail_areas_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_organization_id_organizations_id_fk": {
+          "name": "trails_organization_id_organizations_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_rating_id_trail_ratings_id_fk": {
+          "name": "trails_rating_id_trail_ratings_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_kind_id_trail_kinds_id_fk": {
+          "name": "trails_kind_id_trail_kinds_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._trails_v": {
+      "name": "_trails_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_trail_name": {
+          "name": "version_trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_city": {
+          "name": "version_city",
+          "type": "enum__trails_v_version_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "version_area_id": {
+          "name": "version_area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_organization_id": {
+          "name": "version_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rating_id": {
+          "name": "version_rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_kind_id": {
+          "name": "version_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_condition_reports_closed": {
+          "name": "version_condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_condition_reports_note": {
+          "name": "version_condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_display_name": {
+          "name": "version_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geom": {
+          "name": "version_geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_osm_ids": {
+          "name": "version_osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rebuild_geometry": {
+          "name": "version_rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_osm_report": {
+          "name": "version_osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_distance": {
+          "name": "version_distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_gain": {
+          "name": "version_elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_loss": {
+          "name": "version_elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_min": {
+          "name": "version_elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_max": {
+          "name": "version_elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_bounds": {
+          "name": "version_bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_profile": {
+          "name": "version_elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geometry_source": {
+          "name": "version_geometry_source",
+          "type": "enum__trails_v_version_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__trails_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_trails_v_parent_idx": {
+          "name": "_trails_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_trail_name_idx": {
+          "name": "_trails_v_version_version_trail_name_idx",
+          "columns": [
+            {
+              "expression": "version_trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_area_idx": {
+          "name": "_trails_v_version_version_area_idx",
+          "columns": [
+            {
+              "expression": "version_area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_organization_idx": {
+          "name": "_trails_v_version_version_organization_idx",
+          "columns": [
+            {
+              "expression": "version_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_rating_idx": {
+          "name": "_trails_v_version_version_rating_idx",
+          "columns": [
+            {
+              "expression": "version_rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_kind_idx": {
+          "name": "_trails_v_version_version_kind_idx",
+          "columns": [
+            {
+              "expression": "version_kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_condition_reports_closed_idx": {
+          "name": "_trails_v_version_version_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "version_condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_slug_idx": {
+          "name": "_trails_v_version_version_slug_idx",
+          "columns": [
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_updated_at_idx": {
+          "name": "_trails_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_created_at_idx": {
+          "name": "_trails_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version__status_idx": {
+          "name": "_trails_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_created_at_idx": {
+          "name": "_trails_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_updated_at_idx": {
+          "name": "_trails_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_latest_idx": {
+          "name": "_trails_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_trails_v_parent_id_trails_id_fk": {
+          "name": "_trails_v_parent_id_trails_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_area_id_trail_areas_id_fk": {
+          "name": "_trails_v_version_area_id_trail_areas_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "version_area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_organization_id_organizations_id_fk": {
+          "name": "_trails_v_version_organization_id_organizations_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "version_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_rating_id_trail_ratings_id_fk": {
+          "name": "_trails_v_version_rating_id_trail_ratings_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "version_rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_kind_id_trail_kinds_id_fk": {
+          "name": "_trails_v_version_kind_id_trail_kinds_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "version_kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_conditions": {
+      "name": "trail_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_trail_conditions_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_conditions_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "reporter_hash": {
+          "name": "reporter_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_conditions_trail_idx": {
+          "name": "trail_conditions_trail_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_condition_idx": {
+          "name": "trail_conditions_condition_idx",
+          "columns": [
+            {
+              "expression": "condition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_observed_at_idx": {
+          "name": "trail_conditions_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_hidden_idx": {
+          "name": "trail_conditions_hidden_idx",
+          "columns": [
+            {
+              "expression": "hidden",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_reporter_hash_idx": {
+          "name": "trail_conditions_reporter_hash_idx",
+          "columns": [
+            {
+              "expression": "reporter_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_updated_at_idx": {
+          "name": "trail_conditions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_created_at_idx": {
+          "name": "trail_conditions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_conditions_trail_id_trails_id_fk": {
+          "name": "trail_conditions_trail_id_trails_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trail_conditions_condition_id_trail_condition_types_id_fk": {
+          "name": "trail_conditions_condition_id_trail_condition_types_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_areas": {
+      "name": "trail_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_areas_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_reports_closed": {
+          "name": "condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "condition_reports_note": {
+          "name": "condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_areas_name_idx": {
+          "name": "trail_areas_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_region_idx": {
+          "name": "trail_areas_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_condition_reports_closed_idx": {
+          "name": "trail_areas_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_updated_at_idx": {
+          "name": "trail_areas_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_created_at_idx": {
+          "name": "trail_areas_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_ratings": {
+      "name": "trail_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_ratings_name_idx": {
+          "name": "trail_ratings_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_value_idx": {
+          "name": "trail_ratings_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_updated_at_idx": {
+          "name": "trail_ratings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_created_at_idx": {
+          "name": "trail_ratings_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_kinds": {
+      "name": "trail_kinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "enum_trail_kinds_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mountain'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_kinds_name_idx": {
+          "name": "trail_kinds_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_value_idx": {
+          "name": "trail_kinds_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_updated_at_idx": {
+          "name": "trail_kinds_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_created_at_idx": {
+          "name": "trail_kinds_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_condition_types": {
+      "name": "trail_condition_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_condition_types_name_idx": {
+          "name": "trail_condition_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_value_idx": {
+          "name": "trail_condition_types_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_updated_at_idx": {
+          "name": "trail_condition_types_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_created_at_idx": {
+          "name": "trail_condition_types_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_organizations_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_name_idx": {
+          "name": "organizations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_updated_at_idx": {
+          "name": "organizations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_created_at_idx": {
+          "name": "organizations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_users_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trails_id": {
+          "name": "trails_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_conditions_id": {
+          "name": "trail_conditions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_areas_id": {
+          "name": "trail_areas_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_ratings_id": {
+          "name": "trail_ratings_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_kinds_id": {
+          "name": "trail_kinds_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_condition_types_id": {
+          "name": "trail_condition_types_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizations_id": {
+          "name": "organizations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trails_id_idx": {
+          "name": "payload_locked_documents_rels_trails_id_idx",
+          "columns": [
+            {
+              "expression": "trails_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_conditions_id_idx": {
+          "name": "payload_locked_documents_rels_trail_conditions_id_idx",
+          "columns": [
+            {
+              "expression": "trail_conditions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_areas_id_idx": {
+          "name": "payload_locked_documents_rels_trail_areas_id_idx",
+          "columns": [
+            {
+              "expression": "trail_areas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_ratings_id_idx": {
+          "name": "payload_locked_documents_rels_trail_ratings_id_idx",
+          "columns": [
+            {
+              "expression": "trail_ratings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_kinds_id_idx": {
+          "name": "payload_locked_documents_rels_trail_kinds_id_idx",
+          "columns": [
+            {
+              "expression": "trail_kinds_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_condition_types_id_idx": {
+          "name": "payload_locked_documents_rels_trail_condition_types_id_idx",
+          "columns": [
+            {
+              "expression": "trail_condition_types_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_organizations_id_idx": {
+          "name": "payload_locked_documents_rels_organizations_id_idx",
+          "columns": [
+            {
+              "expression": "organizations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trails_fk": {
+          "name": "payload_locked_documents_rels_trails_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trails_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_conditions_fk": {
+          "name": "payload_locked_documents_rels_trail_conditions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_conditions",
+          "columnsFrom": [
+            "trail_conditions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_areas_fk": {
+          "name": "payload_locked_documents_rels_trail_areas_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "trail_areas_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_ratings_fk": {
+          "name": "payload_locked_documents_rels_trail_ratings_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "trail_ratings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_kinds_fk": {
+          "name": "payload_locked_documents_rels_trail_kinds_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "trail_kinds_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_condition_types_fk": {
+          "name": "payload_locked_documents_rels_trail_condition_types_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "trail_condition_types_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_organizations_fk": {
+          "name": "payload_locked_documents_rels_organizations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organizations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.condition_reporting": {
+      "name": "condition_reporting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "disabled_message": {
+          "name": "disabled_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deep_color": {
+          "name": "deep_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neutral_tint": {
+          "name": "neutral_tint",
+          "type": "enum_theme_neutral_tint",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corner_style": {
+          "name": "corner_style",
+          "type": "enum_theme_corner_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "enum_theme_font_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_trails_city": {
+      "name": "enum_trails_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trails_geometry_source": {
+      "name": "enum_trails_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum_trails_status": {
+      "name": "enum_trails_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__trails_v_version_city": {
+      "name": "enum__trails_v_version_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum__trails_v_version_geometry_source": {
+      "name": "enum__trails_v_version_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum__trails_v_version_status": {
+      "name": "enum__trails_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum_trail_conditions_source": {
+      "name": "enum_trail_conditions_source",
+      "schema": "public",
+      "values": [
+        "public",
+        "admin"
+      ]
+    },
+    "public.enum_trail_conditions_city": {
+      "name": "enum_trail_conditions_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_areas_city": {
+      "name": "enum_trail_areas_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_kinds_icon": {
+      "name": "enum_trail_kinds_icon",
+      "schema": "public",
+      "values": [
+        "mountain",
+        "route"
+      ]
+    },
+    "public.enum_organizations_city": {
+      "name": "enum_organizations_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin"
+      ]
+    },
+    "public.enum_users_city": {
+      "name": "enum_users_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_theme_neutral_tint": {
+      "name": "enum_theme_neutral_tint",
+      "schema": "public",
+      "values": [
+        "cool",
+        "neutral",
+        "warm"
+      ]
+    },
+    "public.enum_theme_corner_style": {
+      "name": "enum_theme_corner_style",
+      "schema": "public",
+      "values": [
+        "sharp",
+        "soft",
+        "round"
+      ]
+    },
+    "public.enum_theme_font_family": {
+      "name": "enum_theme_font_family",
+      "schema": "public",
+      "values": [
+        "geist",
+        "system",
+        "serif"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "14b650a1-e41c-43b1-ba88-fc1a510c5112",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260807_213812_condition_report_locks.ts
+++ b/src/migrations/20260807_213812_condition_report_locks.ts
@@ -1,0 +1,48 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * The three switches that close condition reporting: the `condition_reporting`
+ * global, and a `condition_reports_closed` flag plus note on `trails` and
+ * `trail_areas`.
+ *
+ * No backfill needed by design: the flag is named for the exception, so
+ * `DEFAULT false` leaves every existing trail open — which is what it was. A
+ * positive `accept_condition_reports` would have needed a data migration.
+ *
+ * `_trails_v` gets the same pair because Trails has drafts on.
+ */
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TABLE "condition_reporting" (
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"enabled" boolean DEFAULT true,
+  	"disabled_message" varchar,
+  	"updated_at" timestamp(3) with time zone,
+  	"created_at" timestamp(3) with time zone
+  );
+  
+  ALTER TABLE "trails" ADD COLUMN "condition_reports_closed" boolean DEFAULT false;
+  ALTER TABLE "trails" ADD COLUMN "condition_reports_note" varchar;
+  ALTER TABLE "_trails_v" ADD COLUMN "version_condition_reports_closed" boolean DEFAULT false;
+  ALTER TABLE "_trails_v" ADD COLUMN "version_condition_reports_note" varchar;
+  ALTER TABLE "trail_areas" ADD COLUMN "condition_reports_closed" boolean DEFAULT false;
+  ALTER TABLE "trail_areas" ADD COLUMN "condition_reports_note" varchar;
+  CREATE INDEX "trails_condition_reports_closed_idx" ON "trails" USING btree ("condition_reports_closed");
+  CREATE INDEX "_trails_v_version_version_condition_reports_closed_idx" ON "_trails_v" USING btree ("version_condition_reports_closed");
+  CREATE INDEX "trail_areas_condition_reports_closed_idx" ON "trail_areas" USING btree ("condition_reports_closed");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "condition_reporting" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "condition_reporting" CASCADE;
+  DROP INDEX "trails_condition_reports_closed_idx";
+  DROP INDEX "_trails_v_version_version_condition_reports_closed_idx";
+  DROP INDEX "trail_areas_condition_reports_closed_idx";
+  ALTER TABLE "trails" DROP COLUMN "condition_reports_closed";
+  ALTER TABLE "trails" DROP COLUMN "condition_reports_note";
+  ALTER TABLE "_trails_v" DROP COLUMN "version_condition_reports_closed";
+  ALTER TABLE "_trails_v" DROP COLUMN "version_condition_reports_note";
+  ALTER TABLE "trail_areas" DROP COLUMN "condition_reports_closed";
+  ALTER TABLE "trail_areas" DROP COLUMN "condition_reports_note";`)
+}

--- a/src/migrations/20260807_234413_condition_marks_closed.json
+++ b/src/migrations/20260807_234413_condition_marks_closed.json
@@ -1,0 +1,3037 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.trails": {
+      "name": "trails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_name": {
+          "name": "trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trails_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_id": {
+          "name": "rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind_id": {
+          "name": "kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_reports_closed": {
+          "name": "condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "condition_reports_note": {
+          "name": "condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geom": {
+          "name": "geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_ids": {
+          "name": "osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebuild_geometry": {
+          "name": "rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "osm_report": {
+          "name": "osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_gain": {
+          "name": "elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_loss": {
+          "name": "elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_min": {
+          "name": "elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_max": {
+          "name": "elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounds": {
+          "name": "bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_profile": {
+          "name": "elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_source": {
+          "name": "geometry_source",
+          "type": "enum_trails_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_trails_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "trails_trail_name_idx": {
+          "name": "trails_trail_name_idx",
+          "columns": [
+            {
+              "expression": "trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_area_idx": {
+          "name": "trails_area_idx",
+          "columns": [
+            {
+              "expression": "area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_organization_idx": {
+          "name": "trails_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_rating_idx": {
+          "name": "trails_rating_idx",
+          "columns": [
+            {
+              "expression": "rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_kind_idx": {
+          "name": "trails_kind_idx",
+          "columns": [
+            {
+              "expression": "kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_condition_reports_closed_idx": {
+          "name": "trails_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_slug_idx": {
+          "name": "trails_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_updated_at_idx": {
+          "name": "trails_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails_created_at_idx": {
+          "name": "trails_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trails__status_idx": {
+          "name": "trails__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trails_area_id_trail_areas_id_fk": {
+          "name": "trails_area_id_trail_areas_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_organization_id_organizations_id_fk": {
+          "name": "trails_organization_id_organizations_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_rating_id_trail_ratings_id_fk": {
+          "name": "trails_rating_id_trail_ratings_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trails_kind_id_trail_kinds_id_fk": {
+          "name": "trails_kind_id_trail_kinds_id_fk",
+          "tableFrom": "trails",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._trails_v": {
+      "name": "_trails_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_trail_name": {
+          "name": "version_trail_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_city": {
+          "name": "version_city",
+          "type": "enum__trails_v_version_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'bend'"
+        },
+        "version_area_id": {
+          "name": "version_area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_organization_id": {
+          "name": "version_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rating_id": {
+          "name": "version_rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_kind_id": {
+          "name": "version_kind_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_condition_reports_closed": {
+          "name": "version_condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_condition_reports_note": {
+          "name": "version_condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_display_name": {
+          "name": "version_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geom": {
+          "name": "version_geom",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_osm_ids": {
+          "name": "version_osm_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_rebuild_geometry": {
+          "name": "version_rebuild_geometry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_osm_report": {
+          "name": "version_osm_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_distance": {
+          "name": "version_distance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_gain": {
+          "name": "version_elevation_gain",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_loss": {
+          "name": "version_elevation_loss",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_min": {
+          "name": "version_elevation_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_max": {
+          "name": "version_elevation_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_bounds": {
+          "name": "version_bounds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_elevation_profile": {
+          "name": "version_elevation_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_geometry_source": {
+          "name": "version_geometry_source",
+          "type": "enum__trails_v_version_geometry_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'osm'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__trails_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_trails_v_parent_idx": {
+          "name": "_trails_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_trail_name_idx": {
+          "name": "_trails_v_version_version_trail_name_idx",
+          "columns": [
+            {
+              "expression": "version_trail_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_area_idx": {
+          "name": "_trails_v_version_version_area_idx",
+          "columns": [
+            {
+              "expression": "version_area_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_organization_idx": {
+          "name": "_trails_v_version_version_organization_idx",
+          "columns": [
+            {
+              "expression": "version_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_rating_idx": {
+          "name": "_trails_v_version_version_rating_idx",
+          "columns": [
+            {
+              "expression": "version_rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_kind_idx": {
+          "name": "_trails_v_version_version_kind_idx",
+          "columns": [
+            {
+              "expression": "version_kind_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_condition_reports_closed_idx": {
+          "name": "_trails_v_version_version_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "version_condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_slug_idx": {
+          "name": "_trails_v_version_version_slug_idx",
+          "columns": [
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_updated_at_idx": {
+          "name": "_trails_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version_created_at_idx": {
+          "name": "_trails_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_version_version__status_idx": {
+          "name": "_trails_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_created_at_idx": {
+          "name": "_trails_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_updated_at_idx": {
+          "name": "_trails_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_trails_v_latest_idx": {
+          "name": "_trails_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_trails_v_parent_id_trails_id_fk": {
+          "name": "_trails_v_parent_id_trails_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_area_id_trail_areas_id_fk": {
+          "name": "_trails_v_version_area_id_trail_areas_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "version_area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_organization_id_organizations_id_fk": {
+          "name": "_trails_v_version_organization_id_organizations_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "version_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_rating_id_trail_ratings_id_fk": {
+          "name": "_trails_v_version_rating_id_trail_ratings_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "version_rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_trails_v_version_kind_id_trail_kinds_id_fk": {
+          "name": "_trails_v_version_kind_id_trail_kinds_id_fk",
+          "tableFrom": "_trails_v",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "version_kind_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_conditions": {
+      "name": "trail_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trail_id": {
+          "name": "trail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_trail_conditions_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_conditions_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "reporter_hash": {
+          "name": "reporter_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_conditions_trail_idx": {
+          "name": "trail_conditions_trail_idx",
+          "columns": [
+            {
+              "expression": "trail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_condition_idx": {
+          "name": "trail_conditions_condition_idx",
+          "columns": [
+            {
+              "expression": "condition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_observed_at_idx": {
+          "name": "trail_conditions_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_hidden_idx": {
+          "name": "trail_conditions_hidden_idx",
+          "columns": [
+            {
+              "expression": "hidden",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_reporter_hash_idx": {
+          "name": "trail_conditions_reporter_hash_idx",
+          "columns": [
+            {
+              "expression": "reporter_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_updated_at_idx": {
+          "name": "trail_conditions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_conditions_created_at_idx": {
+          "name": "trail_conditions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trail_conditions_trail_id_trails_id_fk": {
+          "name": "trail_conditions_trail_id_trails_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "trail_conditions_condition_id_trail_condition_types_id_fk": {
+          "name": "trail_conditions_condition_id_trail_condition_types_id_fk",
+          "tableFrom": "trail_conditions",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "condition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_areas": {
+      "name": "trail_areas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_trail_areas_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bend'"
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_reports_closed": {
+          "name": "condition_reports_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "condition_reports_note": {
+          "name": "condition_reports_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_areas_name_idx": {
+          "name": "trail_areas_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_region_idx": {
+          "name": "trail_areas_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_condition_reports_closed_idx": {
+          "name": "trail_areas_condition_reports_closed_idx",
+          "columns": [
+            {
+              "expression": "condition_reports_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_updated_at_idx": {
+          "name": "trail_areas_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_areas_created_at_idx": {
+          "name": "trail_areas_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_ratings": {
+      "name": "trail_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_ratings_name_idx": {
+          "name": "trail_ratings_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_value_idx": {
+          "name": "trail_ratings_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_updated_at_idx": {
+          "name": "trail_ratings_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_ratings_created_at_idx": {
+          "name": "trail_ratings_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_kinds": {
+      "name": "trail_kinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "enum_trail_kinds_icon",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mountain'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_kinds_name_idx": {
+          "name": "trail_kinds_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_value_idx": {
+          "name": "trail_kinds_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_updated_at_idx": {
+          "name": "trail_kinds_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_kinds_created_at_idx": {
+          "name": "trail_kinds_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trail_condition_types": {
+      "name": "trail_condition_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "marks_closed": {
+          "name": "marks_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trail_condition_types_name_idx": {
+          "name": "trail_condition_types_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_value_idx": {
+          "name": "trail_condition_types_value_idx",
+          "columns": [
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_marks_closed_idx": {
+          "name": "trail_condition_types_marks_closed_idx",
+          "columns": [
+            {
+              "expression": "marks_closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_updated_at_idx": {
+          "name": "trail_condition_types_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trail_condition_types_created_at_idx": {
+          "name": "trail_condition_types_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_organizations_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_name_idx": {
+          "name": "organizations_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_updated_at_idx": {
+          "name": "organizations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_created_at_idx": {
+          "name": "organizations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "city": {
+          "name": "city",
+          "type": "enum_users_city",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trails_id": {
+          "name": "trails_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_conditions_id": {
+          "name": "trail_conditions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_areas_id": {
+          "name": "trail_areas_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_ratings_id": {
+          "name": "trail_ratings_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_kinds_id": {
+          "name": "trail_kinds_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trail_condition_types_id": {
+          "name": "trail_condition_types_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizations_id": {
+          "name": "organizations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trails_id_idx": {
+          "name": "payload_locked_documents_rels_trails_id_idx",
+          "columns": [
+            {
+              "expression": "trails_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_conditions_id_idx": {
+          "name": "payload_locked_documents_rels_trail_conditions_id_idx",
+          "columns": [
+            {
+              "expression": "trail_conditions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_areas_id_idx": {
+          "name": "payload_locked_documents_rels_trail_areas_id_idx",
+          "columns": [
+            {
+              "expression": "trail_areas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_ratings_id_idx": {
+          "name": "payload_locked_documents_rels_trail_ratings_id_idx",
+          "columns": [
+            {
+              "expression": "trail_ratings_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_kinds_id_idx": {
+          "name": "payload_locked_documents_rels_trail_kinds_id_idx",
+          "columns": [
+            {
+              "expression": "trail_kinds_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_trail_condition_types_id_idx": {
+          "name": "payload_locked_documents_rels_trail_condition_types_id_idx",
+          "columns": [
+            {
+              "expression": "trail_condition_types_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_organizations_id_idx": {
+          "name": "payload_locked_documents_rels_organizations_id_idx",
+          "columns": [
+            {
+              "expression": "organizations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trails_fk": {
+          "name": "payload_locked_documents_rels_trails_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trails",
+          "columnsFrom": [
+            "trails_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_conditions_fk": {
+          "name": "payload_locked_documents_rels_trail_conditions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_conditions",
+          "columnsFrom": [
+            "trail_conditions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_areas_fk": {
+          "name": "payload_locked_documents_rels_trail_areas_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_areas",
+          "columnsFrom": [
+            "trail_areas_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_ratings_fk": {
+          "name": "payload_locked_documents_rels_trail_ratings_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_ratings",
+          "columnsFrom": [
+            "trail_ratings_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_kinds_fk": {
+          "name": "payload_locked_documents_rels_trail_kinds_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_kinds",
+          "columnsFrom": [
+            "trail_kinds_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_trail_condition_types_fk": {
+          "name": "payload_locked_documents_rels_trail_condition_types_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "trail_condition_types",
+          "columnsFrom": [
+            "trail_condition_types_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_organizations_fk": {
+          "name": "payload_locked_documents_rels_organizations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organizations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.condition_reporting": {
+      "name": "condition_reporting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "disabled_message": {
+          "name": "disabled_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deep_color": {
+          "name": "deep_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neutral_tint": {
+          "name": "neutral_tint",
+          "type": "enum_theme_neutral_tint",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corner_style": {
+          "name": "corner_style",
+          "type": "enum_theme_corner_style",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "font_family": {
+          "name": "font_family",
+          "type": "enum_theme_font_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_css": {
+          "name": "custom_css",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_trails_city": {
+      "name": "enum_trails_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trails_geometry_source": {
+      "name": "enum_trails_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum_trails_status": {
+      "name": "enum_trails_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__trails_v_version_city": {
+      "name": "enum__trails_v_version_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum__trails_v_version_geometry_source": {
+      "name": "enum__trails_v_version_geometry_source",
+      "schema": "public",
+      "values": [
+        "osm",
+        "edited",
+        "imported"
+      ]
+    },
+    "public.enum__trails_v_version_status": {
+      "name": "enum__trails_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum_trail_conditions_source": {
+      "name": "enum_trail_conditions_source",
+      "schema": "public",
+      "values": [
+        "public",
+        "admin"
+      ]
+    },
+    "public.enum_trail_conditions_city": {
+      "name": "enum_trail_conditions_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_areas_city": {
+      "name": "enum_trail_areas_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_trail_kinds_icon": {
+      "name": "enum_trail_kinds_icon",
+      "schema": "public",
+      "values": [
+        "mountain",
+        "route"
+      ]
+    },
+    "public.enum_organizations_city": {
+      "name": "enum_organizations_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin"
+      ]
+    },
+    "public.enum_users_city": {
+      "name": "enum_users_city",
+      "schema": "public",
+      "values": [
+        "chattanooga",
+        "bend"
+      ]
+    },
+    "public.enum_theme_neutral_tint": {
+      "name": "enum_theme_neutral_tint",
+      "schema": "public",
+      "values": [
+        "cool",
+        "neutral",
+        "warm"
+      ]
+    },
+    "public.enum_theme_corner_style": {
+      "name": "enum_theme_corner_style",
+      "schema": "public",
+      "values": [
+        "sharp",
+        "soft",
+        "round"
+      ]
+    },
+    "public.enum_theme_font_family": {
+      "name": "enum_theme_font_family",
+      "schema": "public",
+      "values": [
+        "geist",
+        "system",
+        "serif"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "0b7199dc-1166-4ffa-8106-24e6c7350984",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260807_234413_condition_marks_closed.ts
+++ b/src/migrations/20260807_234413_condition_marks_closed.ts
@@ -1,0 +1,25 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Lets a condition mark the trail closed on the map, rather than the app
+ * hardcoding the value 'closed' — a curator can flag "Snow / ice" the same way.
+ *
+ * The backfill is the point: the column defaults to false, so without it the
+ * existing Closed row would stop meaning anything the moment this shipped.
+ * Matched on `value`, which is the stable key; `name` is a label a curator may
+ * have reworded.
+ */
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "trail_condition_types" ADD COLUMN "marks_closed" boolean DEFAULT false;
+  CREATE INDEX "trail_condition_types_marks_closed_idx" ON "trail_condition_types" USING btree ("marks_closed");`)
+
+  await db.execute(sql`
+  UPDATE "trail_condition_types" SET "marks_closed" = true WHERE "value" = 'closed';`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   DROP INDEX "trail_condition_types_marks_closed_idx";
+  ALTER TABLE "trail_condition_types" DROP COLUMN "marks_closed";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,9 +1,21 @@
 import * as migration_20260807_044718_initial_schema from './20260807_044718_initial_schema';
+import * as migration_20260807_202004_trail_conditions from './20260807_202004_trail_conditions';
+import * as migration_20260807_213812_condition_report_locks from './20260807_213812_condition_report_locks';
 
 export const migrations = [
   {
     up: migration_20260807_044718_initial_schema.up,
     down: migration_20260807_044718_initial_schema.down,
-    name: '20260807_044718_initial_schema'
+    name: '20260807_044718_initial_schema',
+  },
+  {
+    up: migration_20260807_202004_trail_conditions.up,
+    down: migration_20260807_202004_trail_conditions.down,
+    name: '20260807_202004_trail_conditions',
+  },
+  {
+    up: migration_20260807_213812_condition_report_locks.up,
+    down: migration_20260807_213812_condition_report_locks.down,
+    name: '20260807_213812_condition_report_locks'
   },
 ];

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration_20260807_044718_initial_schema from './20260807_044718_initial_schema';
 import * as migration_20260807_202004_trail_conditions from './20260807_202004_trail_conditions';
 import * as migration_20260807_213812_condition_report_locks from './20260807_213812_condition_report_locks';
+import * as migration_20260807_234413_condition_marks_closed from './20260807_234413_condition_marks_closed';
 
 export const migrations = [
   {
@@ -16,6 +17,11 @@ export const migrations = [
   {
     up: migration_20260807_213812_condition_report_locks.up,
     down: migration_20260807_213812_condition_report_locks.down,
-    name: '20260807_213812_condition_report_locks'
+    name: '20260807_213812_condition_report_locks',
+  },
+  {
+    up: migration_20260807_234413_condition_marks_closed.up,
+    down: migration_20260807_234413_condition_marks_closed.down,
+    name: '20260807_234413_condition_marks_closed'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -433,6 +433,10 @@ export interface TrailConditionType {
    */
   active?: boolean | null;
   /**
+   * Draws the trail as a red dashed line, and the badge stops expiring — a closure holds until someone reports something else. Nothing to do with the “closed to new reports” switches on a trail.
+   */
+  marksClosed?: boolean | null;
+  /**
    * What this means locally. Optional.
    */
   description?: string | null;
@@ -669,6 +673,7 @@ export interface TrailConditionTypesSelect<T extends boolean = true> {
   color?: T;
   sortOrder?: T;
   active?: T;
+  marksClosed?: T;
   description?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -68,9 +68,11 @@ export interface Config {
   blocks: {};
   collections: {
     trails: Trail;
+    'trail-conditions': TrailCondition;
     'trail-areas': TrailArea;
     'trail-ratings': TrailRating;
     'trail-kinds': TrailKind;
+    'trail-condition-types': TrailConditionType;
     organizations: Organization;
     users: User;
     'payload-kv': PayloadKv;
@@ -81,9 +83,11 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     trails: TrailsSelect<false> | TrailsSelect<true>;
+    'trail-conditions': TrailConditionsSelect<false> | TrailConditionsSelect<true>;
     'trail-areas': TrailAreasSelect<false> | TrailAreasSelect<true>;
     'trail-ratings': TrailRatingsSelect<false> | TrailRatingsSelect<true>;
     'trail-kinds': TrailKindsSelect<false> | TrailKindsSelect<true>;
+    'trail-condition-types': TrailConditionTypesSelect<false> | TrailConditionTypesSelect<true>;
     organizations: OrganizationsSelect<false> | OrganizationsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -96,9 +100,11 @@ export interface Config {
   };
   fallbackLocale: null;
   globals: {
+    'condition-reporting': ConditionReporting;
     theme: Theme;
   };
   globalsSelect: {
+    'condition-reporting': ConditionReportingSelect<false> | ConditionReportingSelect<true>;
     theme: ThemeSelect<false> | ThemeSelect<true>;
   };
   locale: null;
@@ -156,6 +162,14 @@ export interface Trail {
    * Drives the line colour and sidebar icon, both of which come from the kind and rating rows rather than being stored per trail. Manage the list under Lists → Trail kinds.
    */
   kind: number | TrailKind;
+  /**
+   * Stops new condition reports for this trail. Existing reports stay visible.
+   */
+  conditionReportsClosed?: boolean | null;
+  /**
+   * Optional, e.g. “Closed for logging until 1 May.” Shown in place of the Report button.
+   */
+  conditionReportsNote?: string | null;
   /**
    * The name riders see in the sidebar and the elevation pane.
    */
@@ -259,6 +273,14 @@ export interface TrailArea {
    * Optional.
    */
   description?: string | null;
+  /**
+   * Stops new condition reports for every trail in this complex. Existing reports stay visible.
+   */
+  conditionReportsClosed?: boolean | null;
+  /**
+   * Optional, e.g. “Whole complex shut for the wet season.” Shown in place of the Report button.
+   */
+  conditionReportsNote?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -353,6 +375,71 @@ export interface TrailKind {
   createdAt: string;
 }
 /**
+ * What riders have reported. These are live on the map as soon as they arrive — tick “Hidden” to take one down.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-conditions".
+ */
+export interface TrailCondition {
+  id: number;
+  trail: number | Trail;
+  condition: number | TrailConditionType;
+  /**
+   * When it was ridden, not when this was typed.
+   */
+  observedAt: string;
+  /**
+   * Official means the steward said so, not a rider.
+   */
+  source: 'public' | 'admin';
+  /**
+   * Takes this off the public map. The row stays, so repeat abuse is still visible here.
+   */
+  hidden?: boolean | null;
+  city: 'chattanooga' | 'bend';
+  /**
+   * A one-way hash of the submitter’s IP, so repeat abuse can be found together. The address itself is never stored.
+   */
+  reporterHash?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * What riders can report a trail as being. Anything added here becomes selectable on the report form.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-condition-types".
+ */
+export interface TrailConditionType {
+  id: number;
+  /**
+   * As riders see it, e.g. "Muddy — stay off".
+   */
+  name: string;
+  /**
+   * The stable key the map matches on, e.g. "muddy". Lowercase and dashes.
+   */
+  value: string;
+  /**
+   * The badge colour.
+   */
+  color: string;
+  /**
+   * Low to high, best first. Orders the dropdown.
+   */
+  sortOrder: number;
+  /**
+   * Untick to retire an option. Deleting one that past reports use is blocked.
+   */
+  active?: boolean | null;
+  /**
+   * What this means locally. Optional.
+   */
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * Who can sign in and edit.
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -417,6 +504,10 @@ export interface PayloadLockedDocument {
         value: number | Trail;
       } | null)
     | ({
+        relationTo: 'trail-conditions';
+        value: number | TrailCondition;
+      } | null)
+    | ({
         relationTo: 'trail-areas';
         value: number | TrailArea;
       } | null)
@@ -427,6 +518,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'trail-kinds';
         value: number | TrailKind;
+      } | null)
+    | ({
+        relationTo: 'trail-condition-types';
+        value: number | TrailConditionType;
       } | null)
     | ({
         relationTo: 'organizations';
@@ -489,6 +584,8 @@ export interface TrailsSelect<T extends boolean = true> {
   organization?: T;
   rating?: T;
   kind?: T;
+  conditionReportsClosed?: T;
+  conditionReportsNote?: T;
   displayName?: T;
   slug?: T;
   geom?: T;
@@ -509,6 +606,21 @@ export interface TrailsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-conditions_select".
+ */
+export interface TrailConditionsSelect<T extends boolean = true> {
+  trail?: T;
+  condition?: T;
+  observedAt?: T;
+  source?: T;
+  hidden?: T;
+  city?: T;
+  reporterHash?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "trail-areas_select".
  */
 export interface TrailAreasSelect<T extends boolean = true> {
@@ -516,6 +628,8 @@ export interface TrailAreasSelect<T extends boolean = true> {
   city?: T;
   region?: T;
   description?: T;
+  conditionReportsClosed?: T;
+  conditionReportsNote?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -541,6 +655,20 @@ export interface TrailKindsSelect<T extends boolean = true> {
   value?: T;
   icon?: T;
   color?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trail-condition-types_select".
+ */
+export interface TrailConditionTypesSelect<T extends boolean = true> {
+  name?: T;
+  value?: T;
+  color?: T;
+  sortOrder?: T;
+  active?: T;
   description?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -624,6 +752,25 @@ export interface PayloadMigrationsSelect<T extends boolean = true> {
   createdAt?: T;
 }
 /**
+ * Whether riders can report trail conditions. Turning this off leaves existing reports visible.
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "condition-reporting".
+ */
+export interface ConditionReporting {
+  id: number;
+  /**
+   * Untick to close the report form across the whole map.
+   */
+  enabled?: boolean | null;
+  /**
+   * Optional, e.g. “Conditions are reported on our forum instead.”
+   */
+  disabledMessage?: string | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
  * How the admin looks. Changes apply on the next page load. Clear a field to fall back to the default.
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -651,6 +798,17 @@ export interface Theme {
   customCss?: string | null;
   updatedAt?: string | null;
   createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "condition-reporting_select".
+ */
+export interface ConditionReportingSelect<T extends boolean = true> {
+  enabled?: T;
+  disabledMessage?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -4,10 +4,13 @@ import { postgresAdapter } from '@payloadcms/db-postgres';
 import { buildConfig } from 'payload';
 import { Organizations } from './payload/collections/Organizations';
 import { TrailAreas } from './payload/collections/TrailAreas';
+import { TrailConditions } from './payload/collections/TrailConditions';
+import { TrailConditionTypes } from './payload/collections/TrailConditionTypes';
 import { TrailKinds } from './payload/collections/TrailKinds';
 import { TrailRatings } from './payload/collections/TrailRatings';
 import { Trails } from './payload/collections/Trails';
 import { Users } from './payload/collections/Users';
+import { ConditionReporting } from './payload/globals/ConditionReporting';
 import { Theme } from './payload/globals/Theme';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -41,13 +44,15 @@ export default buildConfig({
   },
   collections: [
     Trails,
+    TrailConditions,
     TrailAreas,
     TrailRatings,
     TrailKinds,
+    TrailConditionTypes,
     Organizations,
     Users,
   ],
-  globals: [Theme],
+  globals: [ConditionReporting, Theme],
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {
     outputFile: path.resolve(dirname, 'payload-types.ts'),

--- a/src/payload/collections/TrailAreas.ts
+++ b/src/payload/collections/TrailAreas.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from 'payload';
 import { activeCityId } from '@/config/map.config';
+import { conditionLockFields } from './condition-lock-fields';
 
 /**
  * Trail complexes — the places trails are grouped under in the sidebar
@@ -88,6 +89,19 @@ export const TrailAreas: CollectionConfig = {
       name: 'description',
       type: 'textarea',
       admin: { description: 'Optional.' },
+    },
+    {
+      type: 'collapsible',
+      label: 'Condition reports',
+      admin: {
+        description:
+          'Close every trail in this complex to new rider reports at once — a seasonal closure, say.',
+        initCollapsed: true,
+      },
+      fields: conditionLockFields({
+        effect: 'for every trail in this complex',
+        example: 'Whole complex shut for the wet season.',
+      }),
     },
   ],
 };

--- a/src/payload/collections/TrailConditionTypes.ts
+++ b/src/payload/collections/TrailConditionTypes.ts
@@ -1,0 +1,95 @@
+import type { CollectionConfig } from 'payload';
+import { slugValidator, valueField } from './vocabulary-fields';
+
+/**
+ * The options behind the dropdown on the public report form.
+ *
+ * Curated like trail-ratings because conditions are local: "Dusty / loose"
+ * matters in Bend in August and nowhere in a Tennessee spring.
+ */
+export const TrailConditionTypes: CollectionConfig = {
+  slug: 'trail-condition-types',
+  labels: {
+    plural: 'Trail conditions',
+    singular: 'Trail condition',
+  },
+  // Best to worst, so the rider's dropdown reads as a scale.
+  defaultSort: 'sortOrder',
+  admin: {
+    useAsTitle: 'name',
+    defaultColumns: ['name', 'value', 'color', 'sortOrder', 'active'],
+    description:
+      'What riders can report a trail as being. Anything added here becomes selectable on the report form.',
+    group: 'Lists',
+    listSearchableFields: ['name', 'value'],
+  },
+  access: {
+    create: ({ req }) => req.user?.role === 'admin',
+    delete: ({ req }) => req.user?.role === 'admin',
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+          unique: true,
+          admin: {
+            description: 'As riders see it, e.g. "Muddy — stay off".',
+            width: '50%',
+          },
+        },
+        valueField(
+          'The stable key the map matches on, e.g. "muddy". Lowercase and dashes.',
+        ),
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'color',
+          type: 'text',
+          required: true,
+          defaultValue: '#6b7280',
+          admin: {
+            components: { Field: '@/payload/components/ColorField#ColorField' },
+            description: 'The badge colour.',
+            width: '50%',
+          },
+          validate: slugValidator.color,
+        },
+        {
+          name: 'sortOrder',
+          type: 'number',
+          required: true,
+          defaultValue: 50,
+          label: 'Sort order',
+          admin: {
+            description: 'Low to high, best first. Orders the dropdown.',
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
+      name: 'active',
+      type: 'checkbox',
+      defaultValue: true,
+      label: 'Offer this on the report form',
+      admin: {
+        description:
+          'Untick to retire an option. Deleting one that past reports use is blocked.',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: { description: 'What this means locally. Optional.' },
+    },
+  ],
+};

--- a/src/payload/collections/TrailConditionTypes.ts
+++ b/src/payload/collections/TrailConditionTypes.ts
@@ -87,6 +87,17 @@ export const TrailConditionTypes: CollectionConfig = {
       },
     },
     {
+      name: 'marksClosed',
+      type: 'checkbox',
+      defaultValue: false,
+      index: true,
+      label: 'Mark the trail as closed on the map',
+      admin: {
+        description:
+          'Draws the trail as a red dashed line, and the badge stops expiring — a closure holds until someone reports something else. Nothing to do with the “closed to new reports” switches on a trail.',
+      },
+    },
+    {
       name: 'description',
       type: 'textarea',
       admin: { description: 'What this means locally. Optional.' },

--- a/src/payload/collections/TrailConditions.ts
+++ b/src/payload/collections/TrailConditions.ts
@@ -1,0 +1,127 @@
+import type { CollectionConfig } from 'payload';
+import { activeCityId } from '@/config/map.config';
+
+/**
+ * Condition reports — "Bear Creek was muddy on Saturday".
+ *
+ * **The admin-only access rules below are deliberate.** Payload mounts its own
+ * REST API at /api/trail-conditions, and these rules are what keep it shut. The
+ * public write goes through /api/map/conditions, which validates first and then
+ * uses the Local API. Relaxing `create` here opens a second, unguarded door.
+ *
+ * No drafts: a report is written once and never edited, so `hidden` is the whole
+ * moderation model. Reports are live as soon as they land — an approval queue
+ * would make "is it muddy today?" useless.
+ */
+export const TrailConditions: CollectionConfig = {
+  slug: 'trail-conditions',
+  labels: {
+    plural: 'Condition reports',
+    singular: 'Condition report',
+  },
+  defaultSort: '-observedAt',
+  admin: {
+    // No natural title — a trail, a condition and a date are each ambiguous
+    // alone. The date at least sorts.
+    useAsTitle: 'observedAt',
+    defaultColumns: ['observedAt', 'trail', 'condition', 'source', 'hidden'],
+    description:
+      'What riders have reported. These are live on the map as soon as they arrive — tick “Hidden” to take one down.',
+    group: 'Conditions',
+  },
+  access: {
+    // See the note above before changing these.
+    create: ({ req }) => req.user?.role === 'admin',
+    delete: ({ req }) => req.user?.role === 'admin',
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'trail',
+          type: 'relationship',
+          relationTo: 'trails',
+          required: true,
+          index: true,
+          admin: { width: '50%' },
+        },
+        {
+          name: 'condition',
+          type: 'relationship',
+          relationTo: 'trail-condition-types',
+          required: true,
+          admin: { width: '50%' },
+        },
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'observedAt',
+          type: 'date',
+          required: true,
+          index: true,
+          label: 'Observed',
+          admin: {
+            date: { pickerAppearance: 'dayOnly' },
+            description: 'When it was ridden, not when this was typed.',
+            width: '50%',
+          },
+        },
+        {
+          name: 'source',
+          type: 'select',
+          required: true,
+          defaultValue: 'public',
+          options: [
+            { label: 'Rider report', value: 'public' },
+            { label: 'Official', value: 'admin' },
+          ],
+          admin: {
+            description: 'Official means the steward said so, not a rider.',
+            width: '50%',
+          },
+        },
+      ],
+    },
+    {
+      name: 'hidden',
+      type: 'checkbox',
+      defaultValue: false,
+      label: 'Hidden',
+      index: true,
+      admin: {
+        description:
+          'Takes this off the public map. The row stays, so repeat abuse is still visible here.',
+      },
+    },
+    {
+      name: 'city',
+      type: 'select',
+      required: true,
+      defaultValue: activeCityId,
+      options: [
+        { label: 'Chattanooga', value: 'chattanooga' },
+        { label: 'Bend', value: 'bend' },
+      ],
+      // Hidden like the one on Trails: a deployment serves one city. Kept
+      // denormalised so the summary query needn't join through to the trail.
+      admin: { hidden: true },
+    },
+    {
+      name: 'reporterHash',
+      type: 'text',
+      index: true,
+      label: 'Reporter',
+      admin: {
+        description:
+          'A one-way hash of the submitter’s IP, so repeat abuse can be found together. The address itself is never stored.',
+        readOnly: true,
+      },
+    },
+  ],
+};

--- a/src/payload/collections/Trails.ts
+++ b/src/payload/collections/Trails.ts
@@ -228,13 +228,28 @@ export const Trails: CollectionConfig = {
               label: 'Condition reports',
               admin: {
                 description:
-                  'Close this trail to new rider reports. The trail complex and Settings → Condition reporting can close it too; any one is enough.',
+                  'Log what this trail is like, and see what riders have said. Closing it below stops rider reports; the trail complex and Settings → Condition reporting can close it too, and any one is enough.',
                 initCollapsed: true,
               },
-              fields: conditionLockFields({
-                effect: 'for this trail',
-                example: 'Closed for logging until 1 May.',
-              }),
+              fields: [
+                {
+                  name: 'conditionLog',
+                  type: 'ui',
+                  label: 'Log a condition',
+                  admin: {
+                    components: {
+                      Field:
+                        '@/payload/components/TrailConditionLog#TrailConditionLog',
+                    },
+                  },
+                },
+                // Closing comes after logging: logging is the daily action, and
+                // closing is the rare, deliberate one.
+                ...conditionLockFields({
+                  effect: 'for this trail',
+                  example: 'Closed for logging until 1 May.',
+                }),
+              ],
             },
             {
               type: 'collapsible',

--- a/src/payload/collections/Trails.ts
+++ b/src/payload/collections/Trails.ts
@@ -1,10 +1,15 @@
-import type { Access, CollectionConfig } from 'payload';
+import type {
+  Access,
+  CollectionBeforeDeleteHook,
+  CollectionConfig,
+} from 'payload';
 import { resolveTrailGeometry } from '@/payload/hooks/resolveTrailGeometry';
 import { activeCityId } from '@/config/map.config';
 import { DEFAULT_KIND_VALUE, UNRATED_VALUE } from '@/data/trail-vocabulary';
 import { parseTrailGeometry } from '@/payload/osm/geometry';
 import { MAX_WAYS_PER_REQUEST } from '@/payload/osm/overpass';
 import { slugify } from '@/utils/string';
+import { conditionLockFields } from './condition-lock-fields';
 import { defaultVocabularyId } from './vocabulary-fields';
 
 /**
@@ -46,6 +51,25 @@ const cityScoped: Access = ({ req }) => {
   return user.city ? { city: { equals: user.city } } : false;
 };
 
+/**
+ * Clears a trail's condition reports before the trail goes.
+ *
+ * `trail_conditions.trail_id` is NOT NULL with an ON DELETE SET NULL foreign key
+ * — Payload generates that pair for a required relationship, and together they
+ * make Postgres refuse the delete. Without this, deleting any trail someone had
+ * reported on would fail with a raw constraint violation.
+ */
+const deleteConditionReports: CollectionBeforeDeleteHook = async ({
+  id,
+  req,
+}) => {
+  await req.payload.delete({
+    collection: 'trail-conditions',
+    req,
+    where: { trail: { equals: id } },
+  });
+};
+
 export const Trails: CollectionConfig = {
   slug: 'trails',
   admin: {
@@ -69,6 +93,7 @@ export const Trails: CollectionConfig = {
   },
   hooks: {
     beforeChange: [resolveTrailGeometry],
+    beforeDelete: [deleteConditionReports],
   },
   fields: [
     /**
@@ -197,6 +222,19 @@ export const Trails: CollectionConfig = {
                   },
                 },
               ],
+            },
+            {
+              type: 'collapsible',
+              label: 'Condition reports',
+              admin: {
+                description:
+                  'Close this trail to new rider reports. The trail complex and Settings → Condition reporting can close it too; any one is enough.',
+                initCollapsed: true,
+              },
+              fields: conditionLockFields({
+                effect: 'for this trail',
+                example: 'Closed for logging until 1 May.',
+              }),
             },
             {
               type: 'collapsible',

--- a/src/payload/collections/condition-lock-fields.ts
+++ b/src/payload/collections/condition-lock-fields.ts
@@ -1,0 +1,36 @@
+import type { Field } from 'payload';
+
+/**
+ * The "closed to new reports" pair, shared by Trails and trail complexes.
+ *
+ * Named for the exception, not the rule: `conditionReportsClosed` defaults to
+ * false, so rows written before this field existed (NULL) read as open.
+ */
+export function conditionLockFields(scope: {
+  /** What ticking the box switches off, e.g. "for this trail". */
+  effect: string;
+  /** An example note for this level. */
+  example: string;
+}): Field[] {
+  return [
+    {
+      name: 'conditionReportsClosed',
+      type: 'checkbox',
+      defaultValue: false,
+      label: 'Closed to new reports',
+      index: true,
+      admin: {
+        description: `Stops new condition reports ${scope.effect}. Existing reports stay visible.`,
+      },
+    },
+    {
+      name: 'conditionReportsNote',
+      type: 'textarea',
+      label: 'Why (shown to riders)',
+      admin: {
+        condition: (data) => data?.conditionReportsClosed === true,
+        description: `Optional, e.g. “${scope.example}” Shown in place of the Report button.`,
+      },
+    },
+  ];
+}

--- a/src/payload/components/DashboardSummary.tsx
+++ b/src/payload/components/DashboardSummary.tsx
@@ -77,6 +77,14 @@ export async function DashboardSummary() {
           tone={summary.withWarnings ? 'attention' : 'plain'}
           value={summary.withWarnings}
         />
+        {/* Plain, never 'attention': riders reporting conditions is the system
+            working. It is here so a sudden spike is visible, not as a chore. */}
+        <Stat
+          href="/admin/collections/trail-conditions"
+          label="Reports"
+          note="filed in the last 7 days"
+          value={summary.reportsThisWeek}
+        />
       </div>
 
       {summary.recent.length > 0 && (

--- a/src/payload/components/TrailConditionLog.tsx
+++ b/src/payload/components/TrailConditionLog.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+/**
+ * Log a condition for the trail you already have open, and see the recent ones.
+ *
+ * Without this, a steward posting "closed, trees down" has to leave the trail,
+ * go to Condition reports, hit Create, and find the trail again in a dropdown of
+ * several hundred — for the one thing they came to say.
+ *
+ * A `ui` field, so it adds no column and needs no migration. It writes through
+ * Payload's own REST API rather than a custom endpoint: the collection's
+ * `create` rule already asks for an admin, and the editor's session satisfies
+ * it. That keeps the public route the only unauthenticated door.
+ *
+ * Reports filed here are `source: 'admin'` — the trail steward saying so, which
+ * the map marks differently from a rider's guess.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useDocumentInfo } from '@payloadcms/ui';
+import { Banner, linkButtonStyle } from './admin-ui';
+
+interface ConditionType {
+  color?: null | string;
+  id: number;
+  name: string;
+  value: string;
+}
+
+interface Report {
+  condition: ConditionType | number;
+  hidden?: boolean | null;
+  id: number;
+  observedAt: string;
+  source: 'admin' | 'public';
+}
+
+const HISTORY_LIMIT = 8;
+
+function today(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+function typeOf(report: Report): ConditionType | null {
+  return typeof report.condition === 'object' ? report.condition : null;
+}
+
+const CONTROL: React.CSSProperties = {
+  background: 'var(--theme-input-bg)',
+  border: '1px solid var(--theme-elevation-150)',
+  borderRadius: 'var(--style-radius-s)',
+  color: 'var(--theme-text)',
+  padding: '0.4rem 0.6rem',
+};
+
+export function TrailConditionLog() {
+  const { id } = useDocumentInfo();
+
+  const [types, setTypes] = useState<ConditionType[]>([]);
+  const [reports, setReports] = useState<Report[]>([]);
+  const [condition, setCondition] = useState('');
+  const [observedAt, setObservedAt] = useState(today);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<null | string>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const loadReports = useCallback(async () => {
+    if (!id) {
+      return;
+    }
+    try {
+      const response = await fetch(
+        `/api/trail-conditions?depth=1&limit=${HISTORY_LIMIT}&sort=-observedAt&where[trail][equals]=${id}`,
+        { credentials: 'include' },
+      );
+      const data = await response.json();
+      setReports(Array.isArray(data?.docs) ? data.docs : []);
+    } catch {
+      // A history that won't load is not worth an error on a form the editor
+      // came here to use for something else.
+      setReports([]);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const response = await fetch(
+          '/api/trail-condition-types?limit=100&sort=sortOrder&where[active][not_equals]=false',
+          { credentials: 'include' },
+        );
+        const data = await response.json();
+        setTypes(Array.isArray(data?.docs) ? data.docs : []);
+      } catch {
+        setTypes([]);
+      }
+      await loadReports();
+      setLoaded(true);
+    }
+    void load();
+  }, [loadReports]);
+
+  async function submit() {
+    if (!id || !condition || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/trail-conditions', {
+        body: JSON.stringify({
+          condition: Number(condition),
+          hidden: false,
+          observedAt: new Date(observedAt).toISOString(),
+          // Filed by a signed-in steward, not a rider.
+          source: 'admin',
+          trail: id,
+        }),
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        setError(data?.errors?.[0]?.message ?? 'Could not save that report.');
+        setBusy(false);
+        return;
+      }
+
+      setCondition('');
+      setObservedAt(today());
+      await loadReports();
+    } catch {
+      setError('Could not reach the server.');
+    }
+    setBusy(false);
+  }
+
+  async function hide(reportId: number) {
+    try {
+      await fetch(`/api/trail-conditions/${reportId}`, {
+        body: JSON.stringify({ hidden: true }),
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        method: 'PATCH',
+      });
+      await loadReports();
+    } catch {
+      setError('Could not hide that report.');
+    }
+  }
+
+  // A report needs a trail to point at, and an unsaved document has no id.
+  if (!id) {
+    return (
+      <div className="field-type">
+        <Banner>
+          Save the trail first, then you can log a condition for it.
+        </Banner>
+      </div>
+    );
+  }
+
+  if (loaded && types.length === 0) {
+    return (
+      <div className="field-type">
+        <Banner tone="warning">
+          No conditions to pick from. Add some under Lists → Trail conditions.
+        </Banner>
+      </div>
+    );
+  }
+
+  return (
+    <div className="field-type">
+      {error && <Banner tone="error">{error}</Banner>}
+
+      <div
+        style={{
+          alignItems: 'end',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.5rem',
+          marginBottom: '0.75rem',
+        }}
+      >
+        <label style={{ display: 'grid', gap: '0.25rem' }}>
+          <span style={{ fontSize: '0.8rem' }}>Condition</span>
+          <select
+            onChange={(event) => setCondition(event.target.value)}
+            style={{ ...CONTROL, minWidth: '12rem' }}
+            value={condition}
+          >
+            <option value="">Pick one…</option>
+            {types.map((type) => (
+              <option key={type.id} value={type.id}>
+                {type.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: 'grid', gap: '0.25rem' }}>
+          <span style={{ fontSize: '0.8rem' }}>Observed</span>
+          <input
+            max={today()}
+            onChange={(event) => setObservedAt(event.target.value)}
+            style={CONTROL}
+            type="date"
+            value={observedAt}
+          />
+        </label>
+
+        <button
+          className="btn btn--style-primary btn--size-small"
+          disabled={!condition || busy}
+          onClick={submit}
+          style={{ margin: 0 }}
+          type="button"
+        >
+          {busy ? 'Saving…' : 'Log condition'}
+        </button>
+      </div>
+
+      {reports.length > 0 && (
+        <table
+          style={{
+            borderCollapse: 'collapse',
+            fontSize: '0.85rem',
+            width: '100%',
+          }}
+        >
+          <tbody>
+            {reports.map((report) => {
+              const type = typeOf(report);
+              return (
+                <tr
+                  key={report.id}
+                  style={{
+                    borderTop: '1px solid var(--theme-elevation-100)',
+                    opacity: report.hidden ? 0.45 : 1,
+                  }}
+                >
+                  <td style={{ padding: '0.35rem 0.5rem 0.35rem 0' }}>
+                    <span
+                      style={{
+                        background: type?.color ?? 'var(--theme-elevation-300)',
+                        borderRadius: '50%',
+                        display: 'inline-block',
+                        height: '0.6rem',
+                        marginRight: '0.5rem',
+                        width: '0.6rem',
+                      }}
+                    />
+                    {type?.name ?? 'Unknown'}
+                  </td>
+                  <td style={{ color: 'var(--theme-elevation-600)' }}>
+                    {new Date(report.observedAt).toLocaleDateString()}
+                  </td>
+                  <td style={{ color: 'var(--theme-elevation-600)' }}>
+                    {report.source === 'admin' ? 'Official' : 'Rider'}
+                  </td>
+                  <td style={{ textAlign: 'right' }}>
+                    {report.hidden ? (
+                      <span style={{ color: 'var(--theme-elevation-500)' }}>
+                        Hidden
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => hide(report.id)}
+                        style={linkButtonStyle('danger')}
+                        type="button"
+                      >
+                        Hide
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {loaded && reports.length === 0 && (
+        <p style={{ color: 'var(--theme-elevation-500)', margin: 0 }}>
+          Nothing reported yet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/payload/conditions/guard.test.ts
+++ b/src/payload/conditions/guard.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clientAddress,
+  hashReporter,
+  HONEYPOT_FIELD,
+  isHoneypotTripped,
+  OBSERVED_WINDOW,
+  parseIdentifier,
+  parseObservedAt,
+  reporterSalt,
+} from './guard';
+
+/** A fixed "now" so the date-window tests don't drift with the clock. */
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+
+function daysBefore(days: number): string {
+  const date = new Date(NOW);
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+describe('isHoneypotTripped', () => {
+  it('is not tripped by an absent or empty field', () => {
+    expect(isHoneypotTripped({})).toBe(false);
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: '' })).toBe(false);
+    // Whitespace only is still a human who tabbed through it somehow.
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: '   ' })).toBe(false);
+  });
+
+  it('is tripped by anything typed into it', () => {
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: 'http://spam.example' })).toBe(
+      true,
+    );
+  });
+
+  it('ignores non-string values rather than throwing', () => {
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: 42 })).toBe(false);
+    expect(isHoneypotTripped({ [HONEYPOT_FIELD]: null })).toBe(false);
+  });
+});
+
+describe('clientAddress', () => {
+  it('takes the first entry of x-forwarded-for', () => {
+    const headers = new Headers({
+      'x-forwarded-for': '203.0.113.5, 70.41.3.18, 150.172.238.178',
+    });
+    expect(clientAddress(headers)).toBe('203.0.113.5');
+  });
+
+  it('falls back to x-real-ip, then to a constant', () => {
+    expect(clientAddress(new Headers({ 'x-real-ip': '203.0.113.9' }))).toBe(
+      '203.0.113.9',
+    );
+    expect(clientAddress(new Headers())).toBe('unknown');
+  });
+
+  it('does not return an empty string from a malformed header', () => {
+    expect(clientAddress(new Headers({ 'x-forwarded-for': ' , ' }))).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('hashReporter', () => {
+  it('is stable for the same address and salt', () => {
+    expect(hashReporter('203.0.113.5', 'pepper')).toBe(
+      hashReporter('203.0.113.5', 'pepper'),
+    );
+  });
+
+  it('separates different addresses, and different salts', () => {
+    expect(hashReporter('203.0.113.5', 'pepper')).not.toBe(
+      hashReporter('203.0.113.6', 'pepper'),
+    );
+    // Rotating the salt must invalidate the old buckets, or rotation is a no-op.
+    expect(hashReporter('203.0.113.5', 'pepper')).not.toBe(
+      hashReporter('203.0.113.5', 'salt'),
+    );
+  });
+
+  it('does not contain the address it was made from', () => {
+    const hash = hashReporter('203.0.113.5', 'pepper');
+    expect(hash).not.toContain('203.0.113.5');
+    expect(hash).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe('reporterSalt', () => {
+  it('prefers its own variable, falls back to the Payload secret', () => {
+    expect(
+      reporterSalt({
+        CONDITION_REPORT_SALT: 'own',
+        PAYLOAD_SECRET: 'payload',
+      }),
+    ).toBe('own');
+    expect(reporterSalt({ PAYLOAD_SECRET: 'payload' })).toBe('payload');
+  });
+
+  it('still returns something when neither is set', () => {
+    // A weak salt is bad; an empty one that makes every hash identical, and so
+    // rate-limits the whole internet as one person, is worse.
+    expect(reporterSalt({})).toBeTruthy();
+  });
+});
+
+describe('parseObservedAt', () => {
+  it('accepts today and yesterday', () => {
+    expect(parseObservedAt(NOW.toISOString(), NOW).ok).toBe(true);
+    expect(parseObservedAt(daysBefore(1), NOW).ok).toBe(true);
+  });
+
+  it('accepts a date at the far edge of the window', () => {
+    expect(
+      parseObservedAt(daysBefore(OBSERVED_WINDOW.maxPastDays - 1), NOW).ok,
+    ).toBe(true);
+  });
+
+  it('rejects a date beyond the past window', () => {
+    const result = parseObservedAt(daysBefore(60), NOW);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/older than/);
+  });
+
+  it('rejects next week', () => {
+    const nextWeek = new Date(NOW);
+    nextWeek.setDate(nextWeek.getDate() + 7);
+    const result = parseObservedAt(nextWeek.toISOString(), NOW);
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/future/);
+  });
+
+  it('allows a day of slack forward, for riders ahead of the server', () => {
+    const soon = new Date(NOW);
+    soon.setHours(soon.getHours() + 12);
+    expect(parseObservedAt(soon.toISOString(), NOW).ok).toBe(true);
+  });
+
+  it('rejects unparseable and non-date input', () => {
+    expect(parseObservedAt('last tuesday', NOW).ok).toBe(false);
+    expect(parseObservedAt(undefined, NOW).ok).toBe(false);
+    expect(parseObservedAt(1_754_000_000_000, NOW).ok).toBe(false);
+  });
+
+  it('accepts a Date as well as a string', () => {
+    expect(parseObservedAt(new Date(NOW), NOW).ok).toBe(true);
+  });
+});
+
+describe('parseIdentifier', () => {
+  it('trims and returns a plausible slug', () => {
+    expect(parseIdentifier('  pointe-break ')).toBe('pointe-break');
+  });
+
+  it('rejects blanks, non-strings and anything oversized', () => {
+    expect(parseIdentifier('')).toBeNull();
+    expect(parseIdentifier('   ')).toBeNull();
+    expect(parseIdentifier(null)).toBeNull();
+    expect(parseIdentifier(['pointe-break'])).toBeNull();
+    expect(parseIdentifier('x'.repeat(201))).toBeNull();
+  });
+});

--- a/src/payload/conditions/guard.ts
+++ b/src/payload/conditions/guard.ts
@@ -1,0 +1,137 @@
+/**
+ * Checks that stand between the public report form and the database.
+ *
+ * Pure — no Payload import, no `server-only` — so these are testable without a
+ * database. The parts that need Payload live in `submit.ts`.
+ *
+ * A honeypot and a rate limit, no captcha: this is a regional trail map, the
+ * realistic abuse is one bored local or a scraper, and anything more would be
+ * configuration every fork has to do (ADR-0001 C3). A captcha would go here.
+ */
+import { createHash } from 'node:crypto';
+
+/** The hidden form field. Anything that fills it in is not a person. */
+export const HONEYPOT_FIELD = 'website';
+
+export const RATE_LIMIT = {
+  /** Reports one source may file in an hour, across all trails. */
+  perHour: 5,
+  /** Minutes one source must wait before re-reporting the *same* trail. */
+  perTrailMinutes: 30,
+};
+
+/** How far back an observation may be dated, and how far forward. */
+export const OBSERVED_WINDOW = {
+  maxFutureHours: 24,
+  maxPastDays: 30,
+};
+
+export interface ReportBody {
+  condition?: unknown;
+  observedAt?: unknown;
+  slug?: unknown;
+  [HONEYPOT_FIELD]?: unknown;
+}
+
+/**
+ * Callers should answer a tripped honeypot with a plain 200 and no write. An
+ * error would tell the bot which field is the trap.
+ */
+export function isHoneypotTripped(body: ReportBody): boolean {
+  const value = body[HONEYPOT_FIELD];
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * The submitter's address, as far as it can be trusted.
+ *
+ * `x-forwarded-for` is client-settable, so this is only the real client when
+ * something in front of the app rewrites it — true on Vercel and behind a normal
+ * proxy, false if the app is exposed directly. Good enough for a speed bump.
+ */
+export function clientAddress(headers: Headers): string {
+  const forwarded = headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) {
+      return first;
+    }
+  }
+  return headers.get('x-real-ip')?.trim() || 'unknown';
+}
+
+/**
+ * A salted one-way hash of an address. The address itself is never stored — this
+ * is enough to count one person's reports and find the rest of them, and not
+ * enough to work back to who they are. Truncated; a rate-limit bucket needs no
+ * more.
+ */
+export function hashReporter(address: string, salt: string): string {
+  return createHash('sha256')
+    .update(`${salt}:${address}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/**
+ * Optional on purpose: falling back to `PAYLOAD_SECRET` means a fork gets salted
+ * hashes without setting anything. Set `CONDITION_REPORT_SALT` to rotate the
+ * hashes without signing anyone out.
+ */
+export function reporterSalt(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return env.CONDITION_REPORT_SALT || env.PAYLOAD_SECRET || 'bikemap';
+}
+
+export type ParsedObservedAt =
+  | { error: string; ok: false }
+  | { ok: true; value: Date };
+
+/**
+ * Validates the "when did you ride it" date. Bounded both ways: a future date
+ * would sit at the top of the feed until it arrived, and an old one is not a
+ * condition. The day of forward slack is for riders ahead of the server.
+ */
+export function parseObservedAt(
+  value: unknown,
+  now: Date = new Date(),
+): ParsedObservedAt {
+  if (typeof value !== 'string' && !(value instanceof Date)) {
+    return { error: 'A date is required.', ok: false };
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return { error: 'That date could not be read.', ok: false };
+  }
+
+  const future = new Date(now);
+  future.setHours(future.getHours() + OBSERVED_WINDOW.maxFutureHours);
+  if (parsed > future) {
+    return { error: 'That date is in the future.', ok: false };
+  }
+
+  const past = new Date(now);
+  past.setDate(past.getDate() - OBSERVED_WINDOW.maxPastDays);
+  if (parsed < past) {
+    return {
+      error: `Reports older than ${OBSERVED_WINDOW.maxPastDays} days are not much use to anyone — please leave this one out.`,
+      ok: false,
+    };
+  }
+
+  return { ok: true, value: parsed };
+}
+
+/** Rejects anything that isn't a plausible slug before it becomes a query. */
+export function parseIdentifier(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 200) {
+    return null;
+  }
+  return trimmed;
+}

--- a/src/payload/conditions/submit.ts
+++ b/src/payload/conditions/submit.ts
@@ -200,6 +200,7 @@ export async function submitConditionReport(
       ok: true,
       report: {
         color: type.color || DEFAULT_CONDITION_COLOR,
+        marksClosed: type.marksClosed === true,
         name: type.name,
         observedAt: input.observedAt.toISOString(),
         source: 'public',

--- a/src/payload/conditions/submit.ts
+++ b/src/payload/conditions/submit.ts
@@ -1,0 +1,217 @@
+import 'server-only';
+
+/**
+ * The one door an anonymous condition report comes through.
+ *
+ * Everything deciding whether a report is allowed happens here, before the
+ * write — which uses the Local API and so skips collection access control. See
+ * the note on the TrailConditions collection.
+ *
+ * Returns a result rather than throwing: a rate-limited rider is an ordinary
+ * outcome needing a sentence, not an exception.
+ */
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import type { CityId } from '@/data/cities/types';
+import {
+  type ConditionReport,
+  resolveLockMessage,
+} from '@/data/trail-conditions';
+import { DEFAULT_CONDITION_COLOR } from '@/data/condition-vocabulary';
+import { RATE_LIMIT } from './guard';
+
+export interface SubmitInput {
+  city: CityId;
+  /** The condition's stable `value`, not its name. */
+  condition: string;
+  observedAt: Date;
+  reporterHash: string;
+  /** The trail's slug. */
+  slug: string;
+}
+
+export type SubmitResult =
+  | {
+      ok: false;
+      reason: 'locked' | 'not-found' | 'rate-limited' | 'unavailable';
+      message: string;
+    }
+  | { ok: true; report: ConditionReport };
+
+function minutesAgo(minutes: number): string {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() - minutes);
+  return date.toISOString();
+}
+
+function hoursAgo(hours: number): string {
+  const date = new Date();
+  date.setHours(date.getHours() - hours);
+  return date.toISOString();
+}
+
+export async function submitConditionReport(
+  input: SubmitInput,
+): Promise<SubmitResult> {
+  if (!process.env.DATABASE_URL) {
+    return {
+      message: 'Reports are not available on this map.',
+      ok: false,
+      reason: 'unavailable',
+    };
+  }
+
+  try {
+    const payload = await getPayload({ config });
+
+    // Both lookups are by the caller's strings, so they are the point at which
+    // an arbitrary slug becomes a real row or nothing at all.
+    const [trails, types, settings] = await Promise.all([
+      payload.find({
+        collection: 'trails',
+        // 1 so the trail's complex arrives as a document — its lock is checked
+        // below, and fetching it separately would cost a round trip per report.
+        depth: 1,
+        limit: 1,
+        pagination: false,
+        select: {
+          area: true,
+          conditionReportsClosed: true,
+          conditionReportsNote: true,
+          slug: true,
+        },
+        where: {
+          and: [
+            { slug: { equals: input.slug } },
+            { city: { equals: input.city } },
+            { _status: { equals: 'published' } },
+          ],
+        },
+      }),
+      payload.find({
+        collection: 'trail-condition-types',
+        depth: 0,
+        limit: 1,
+        pagination: false,
+        where: {
+          and: [
+            { value: { equals: input.condition } },
+            // A retired option is not on the form, so a request carrying one
+            // did not come from the form.
+            { active: { not_equals: false } },
+          ],
+        },
+      }),
+      payload.findGlobal({ slug: 'condition-reporting', depth: 0 }),
+    ]);
+
+    const trail = trails.docs[0];
+    const type = types.docs[0];
+    if (!trail || !type) {
+      return {
+        message: 'That trail or condition is not one we know about.',
+        ok: false,
+        reason: 'not-found',
+      };
+    }
+
+    // Three levels, any one of which closes reporting. Checked here because
+    // hiding the button on the client is only a courtesy.
+
+    const area =
+      trail.area && typeof trail.area === 'object' ? trail.area : null;
+    const closed =
+      settings?.enabled === false ||
+      trail.conditionReportsClosed === true ||
+      area?.conditionReportsClosed === true;
+
+    if (closed) {
+      return {
+        // Same precedence the summary uses for the button's label.
+        message: resolveLockMessage(
+          settings?.enabled === false ? settings?.disabledMessage : null,
+          trail.conditionReportsNote,
+          area?.conditionReportsNote,
+        ),
+        ok: false,
+        reason: 'locked',
+      };
+    }
+
+    // Two limits: the hourly cap stops one person rewriting the whole map, the
+    // per-trail cooldown stops one opinion being repeated until it looks agreed.
+    const [recent, sameTrail] = await Promise.all([
+      payload.count({
+        collection: 'trail-conditions',
+        where: {
+          and: [
+            { reporterHash: { equals: input.reporterHash } },
+            { createdAt: { greater_than: hoursAgo(1) } },
+          ],
+        },
+      }),
+      payload.count({
+        collection: 'trail-conditions',
+        where: {
+          and: [
+            { reporterHash: { equals: input.reporterHash } },
+            { trail: { equals: trail.id } },
+            {
+              createdAt: {
+                greater_than: minutesAgo(RATE_LIMIT.perTrailMinutes),
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    if (sameTrail.totalDocs > 0) {
+      return {
+        message: `You have already reported this trail in the last ${RATE_LIMIT.perTrailMinutes} minutes. Thanks — that is enough for now.`,
+        ok: false,
+        reason: 'rate-limited',
+      };
+    }
+
+    if (recent.totalDocs >= RATE_LIMIT.perHour) {
+      return {
+        message: `That is ${RATE_LIMIT.perHour} reports in an hour, which is our limit. Please try again later.`,
+        ok: false,
+        reason: 'rate-limited',
+      };
+    }
+
+    await payload.create({
+      collection: 'trail-conditions',
+      data: {
+        city: input.city,
+        condition: type.id,
+        hidden: false,
+        observedAt: input.observedAt.toISOString(),
+        reporterHash: input.reporterHash,
+        // Anything through this door is a rider; 'admin' is set by hand in the CMS.
+        source: 'public',
+        trail: trail.id,
+      },
+    });
+
+    return {
+      ok: true,
+      report: {
+        color: type.color || DEFAULT_CONDITION_COLOR,
+        name: type.name,
+        observedAt: input.observedAt.toISOString(),
+        source: 'public',
+        value: type.value,
+      },
+    };
+  } catch (error) {
+    console.error('Could not file a condition report.', error);
+    return {
+      message: 'Something went wrong saving that. Please try again.',
+      ok: false,
+      reason: 'unavailable',
+    };
+  }
+}

--- a/src/payload/globals/ConditionReporting.ts
+++ b/src/payload/globals/ConditionReporting.ts
@@ -1,0 +1,45 @@
+import type { GlobalConfig } from 'payload';
+
+/**
+ * The site-wide switch for condition reporting.
+ *
+ * The outermost of three — this, a trail complex, and a single trail — and any
+ * one of them being off closes reporting. Mainly here for a fork that wants the
+ * trail data without a public form.
+ *
+ * Turns off *new reports*, not the display: existing ones stay visible.
+ */
+export const ConditionReporting: GlobalConfig = {
+  slug: 'condition-reporting',
+  label: 'Condition reporting',
+  admin: {
+    description:
+      'Whether riders can report trail conditions. Turning this off leaves existing reports visible.',
+    group: 'Settings',
+  },
+  access: {
+    read: ({ req }) => Boolean(req.user),
+    update: ({ req }) => req.user?.role === 'admin',
+  },
+  fields: [
+    {
+      name: 'enabled',
+      type: 'checkbox',
+      defaultValue: true,
+      label: 'Accept condition reports',
+      admin: {
+        description: 'Untick to close the report form across the whole map.',
+      },
+    },
+    {
+      name: 'disabledMessage',
+      type: 'textarea',
+      label: 'Why (shown to riders)',
+      admin: {
+        condition: (data) => data?.enabled === false,
+        description:
+          'Optional, e.g. “Conditions are reported on our forum instead.”',
+      },
+    },
+  ],
+};

--- a/src/payload/read/conditions.ts
+++ b/src/payload/read/conditions.ts
@@ -1,0 +1,299 @@
+import 'server-only';
+
+/**
+ * Reads condition reports out of Payload for the public map.
+ *
+ * **Never throws**, same contract as `trails.ts` — conditions are a decoration
+ * on a map that works without them, so a database hiccup costs a badge, not the
+ * page.
+ */
+import { getPayload } from 'payload';
+import config from '@payload-config';
+import type { CityId } from '@/data/cities/types';
+import {
+  CONDITION_SUMMARY_DAYS,
+  DEFAULT_CONDITION_COLOR,
+} from '@/data/condition-vocabulary';
+import {
+  type ConditionOption,
+  type ConditionReport,
+  type ConditionSummary,
+  resolveLockMessage,
+} from '@/data/trail-conditions';
+import type {
+  Trail,
+  TrailCondition,
+  TrailConditionType,
+} from '@/payload-types';
+
+/**
+ * At depth 1 a relationship arrives as its document — but only while the row
+ * still points at one. A deleted condition leaves an id or a null; neither
+ * should throw. Same unwrap `trails.ts` does for `rating`.
+ */
+function typeOf(report: TrailCondition): TrailConditionType | null {
+  return report.condition && typeof report.condition === 'object'
+    ? report.condition
+    : null;
+}
+
+function trailOf(report: TrailCondition): Trail | null {
+  return report.trail && typeof report.trail === 'object' ? report.trail : null;
+}
+
+function toOption(row: TrailConditionType): ConditionOption {
+  return {
+    color: row.color || DEFAULT_CONDITION_COLOR,
+    description: row.description ?? undefined,
+    name: row.name,
+    value: row.value,
+  };
+}
+
+/**
+ * Colour and name come off the vocabulary row rather than the report, so
+ * recolouring a condition repaints every badge that used it.
+ */
+function toReport(report: TrailCondition): ConditionReport | null {
+  const type = typeOf(report);
+  if (!type || !report.observedAt) {
+    return null;
+  }
+  return {
+    color: type.color || DEFAULT_CONDITION_COLOR,
+    name: type.name,
+    observedAt: new Date(report.observedAt).toISOString(),
+    source: report.source === 'admin' ? 'admin' : 'public',
+    value: type.value,
+  };
+}
+
+const NO_SUMMARY: ConditionSummary = {
+  latest: {},
+  locked: {},
+  options: [],
+  // Open: a failure should not read as a deliberate closure.
+  reporting: { enabled: true, message: '' },
+};
+
+/** The cutoff the summary query uses, as an ISO string. */
+function summaryCutoff(now = new Date()): string {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - CONDITION_SUMMARY_DAYS);
+  return cutoff.toISOString();
+}
+
+/**
+ * The trails closed to new reports, and the note to show for each.
+ *
+ * Two targeted queries rather than reading every trail — only closed complexes
+ * and closed trails come back. Sequential because the second needs the first's
+ * ids.
+ */
+async function lockedTrails(
+  payload: Awaited<ReturnType<typeof getPayload>>,
+  city: CityId,
+): Promise<Record<string, string>> {
+  const inCity = { city: { equals: city } };
+
+  const closedAreas = await payload.find({
+    collection: 'trail-areas',
+    depth: 0,
+    limit: 500,
+    pagination: false,
+    select: { conditionReportsNote: true },
+    where: { and: [inCity, { conditionReportsClosed: { equals: true } }] },
+  });
+
+  const areaNotes = new Map<number, string>();
+  for (const area of closedAreas.docs) {
+    areaNotes.set(area.id, area.conditionReportsNote ?? '');
+  }
+
+  const closedTrails = await payload.find({
+    collection: 'trails',
+    // 0: `area` arrives as an id, which is all the lookup above needs.
+    depth: 0,
+    limit: 2000,
+    pagination: false,
+    select: { area: true, conditionReportsNote: true, slug: true },
+    where: {
+      and: [
+        inCity,
+        { _status: { equals: 'published' } },
+        {
+          or: [
+            { conditionReportsClosed: { equals: true } },
+            ...(areaNotes.size > 0
+              ? [{ area: { in: [...areaNotes.keys()] } }]
+              : []),
+          ],
+        },
+      ],
+    },
+  });
+
+  const locked: Record<string, string> = {};
+  for (const trail of closedTrails.docs) {
+    if (!trail.slug) {
+      continue;
+    }
+    const areaId = typeof trail.area === 'number' ? trail.area : trail.area?.id;
+    // No site-wide note here: this only runs when the site switch is on, and
+    // `disabledMessage` may still hold text from the last time it was off.
+    locked[trail.slug] = resolveLockMessage(
+      trail.conditionReportsNote,
+      areaId === undefined ? undefined : areaNotes.get(areaId),
+    );
+  }
+
+  return locked;
+}
+
+/**
+ * The dropdown's options, the newest visible report per trail, and wherever
+ * reporting is switched off.
+ *
+ * The reports are one query reduced in JS, not one per trail. Postgres can say
+ * "latest per group" better, but only via a lateral join Payload's query builder
+ * can't express, and a few hundred rows don't justify raw SQL.
+ */
+export async function getConditionSummary(
+  city: CityId,
+): Promise<ConditionSummary> {
+  if (!process.env.DATABASE_URL) {
+    return NO_SUMMARY;
+  }
+
+  try {
+    const payload = await getPayload({ config });
+
+    const [types, reports, settings] = await Promise.all([
+      payload.find({
+        collection: 'trail-condition-types',
+        depth: 0,
+        limit: 100,
+        pagination: false,
+        sort: 'sortOrder',
+        where: { active: { not_equals: false } },
+      }),
+      payload.find({
+        collection: 'trail-conditions',
+        // 1 so `condition` and `trail` resolve to documents rather than ids.
+        depth: 1,
+        limit: 5000,
+        pagination: false,
+        sort: '-observedAt',
+        where: {
+          and: [
+            { city: { equals: city } },
+            { hidden: { not_equals: true } },
+            { observedAt: { greater_than: summaryCutoff() } },
+          ],
+        },
+      }),
+      payload.findGlobal({ slug: 'condition-reporting', depth: 0 }),
+    ]);
+
+    // A global nobody has opened has no row at all, so absent means on.
+    const enabled = settings?.enabled !== false;
+    const siteNote = settings?.disabledMessage ?? '';
+
+    const latest: Record<string, ConditionReport> = {};
+    for (const row of reports.docs) {
+      const trail = trailOf(row);
+      // A report whose trail is gone shouldn't be reachable — Trails deletes its
+      // reports first — but a direct SQL delete would leave one.
+      if (!trail?.slug || latest[trail.slug]) {
+        continue;
+      }
+      const report = toReport(row);
+      if (report) {
+        latest[trail.slug] = report;
+      }
+    }
+
+    return {
+      latest,
+      // Skipped when the site switch is off — `reporting` already says every
+      // trail is closed, in one field rather than hundreds of identical entries.
+      locked: enabled ? await lockedTrails(payload, city) : {},
+      options: types.docs.map(toOption),
+      reporting: { enabled, message: siteNote },
+    };
+  } catch (error) {
+    console.error(
+      `Could not read trail conditions for "${city}" from Payload; the map will show none.`,
+      error,
+    );
+    return NO_SUMMARY;
+  }
+}
+
+/** How many past reports a trail's history shows. */
+const HISTORY_LIMIT = 20;
+
+/**
+ * One trail's recent reports, newest first.
+ *
+ * Returns `null` only when the trail itself is unknown, so the route can tell a
+ * 404 from a trail nobody has reported on yet — which answers `[]`.
+ */
+export async function getTrailConditionHistory(
+  slug: string,
+  city: CityId,
+): Promise<ConditionReport[] | null> {
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  try {
+    const payload = await getPayload({ config });
+
+    const trails = await payload.find({
+      collection: 'trails',
+      depth: 0,
+      limit: 1,
+      pagination: false,
+      select: { slug: true },
+      where: {
+        and: [
+          { slug: { equals: slug } },
+          { city: { equals: city } },
+          { _status: { equals: 'published' } },
+        ],
+      },
+    });
+
+    const trail = trails.docs[0];
+    if (!trail) {
+      return null;
+    }
+
+    const reports = await payload.find({
+      collection: 'trail-conditions',
+      depth: 1,
+      limit: HISTORY_LIMIT,
+      pagination: false,
+      sort: '-observedAt',
+      where: {
+        and: [
+          { trail: { equals: trail.id } },
+          { hidden: { not_equals: true } },
+        ],
+      },
+    });
+
+    return reports.docs
+      .map(toReport)
+      .filter((report): report is ConditionReport => report !== null);
+  } catch (error) {
+    console.error(
+      `Could not read condition history for "${slug}" from Payload.`,
+      error,
+    );
+    // Not null: the trail may well exist, and a 404 would send someone looking
+    // for one that is right there.
+    return [];
+  }
+}

--- a/src/payload/read/conditions.ts
+++ b/src/payload/read/conditions.ts
@@ -10,10 +10,7 @@ import 'server-only';
 import { getPayload } from 'payload';
 import config from '@payload-config';
 import type { CityId } from '@/data/cities/types';
-import {
-  CONDITION_SUMMARY_DAYS,
-  DEFAULT_CONDITION_COLOR,
-} from '@/data/condition-vocabulary';
+import { DEFAULT_CONDITION_COLOR } from '@/data/condition-vocabulary';
 import {
   type ConditionOption,
   type ConditionReport,
@@ -61,6 +58,7 @@ function toReport(report: TrailCondition): ConditionReport | null {
   }
   return {
     color: type.color || DEFAULT_CONDITION_COLOR,
+    marksClosed: type.marksClosed === true,
     name: type.name,
     observedAt: new Date(report.observedAt).toISOString(),
     source: report.source === 'admin' ? 'admin' : 'public',
@@ -75,13 +73,6 @@ const NO_SUMMARY: ConditionSummary = {
   // Open: a failure should not read as a deliberate closure.
   reporting: { enabled: true, message: '' },
 };
-
-/** The cutoff the summary query uses, as an ISO string. */
-function summaryCutoff(now = new Date()): string {
-  const cutoff = new Date(now);
-  cutoff.setDate(cutoff.getDate() - CONDITION_SUMMARY_DAYS);
-  return cutoff.toISOString();
-}
 
 /**
  * The trails closed to new reports, and the note to show for each.
@@ -184,12 +175,16 @@ export async function getConditionSummary(
         limit: 5000,
         pagination: false,
         sort: '-observedAt',
+        // No date floor. A closure holds until someone reports something else,
+        // so the newest report per trail has to be found at any age — a window
+        // would quietly reopen a trail shut last season. Freshness is applied
+        // per report on the client, which is where the rule lives.
+        //
+        // The limit is the bound instead: newest-first means the newest report
+        // per trail is in there while total non-hidden reports stay under it.
+        // Past that, the answer is a current-condition column on the trail.
         where: {
-          and: [
-            { city: { equals: city } },
-            { hidden: { not_equals: true } },
-            { observedAt: { greater_than: summaryCutoff() } },
-          ],
+          and: [{ city: { equals: city } }, { hidden: { not_equals: true } }],
         },
       }),
       payload.findGlobal({ slug: 'condition-reporting', depth: 0 }),

--- a/src/payload/read/summary.ts
+++ b/src/payload/read/summary.ts
@@ -31,6 +31,8 @@ export interface TrailSummary {
   missingProfile: null | number;
   /** Whose last build reported a gap, a missing way, or a failed fetch. */
   withWarnings: null | number;
+  /** Condition reports filed in the last seven days, hidden ones included. */
+  reportsThisWeek: null | number;
   /** Most recently edited, for picking up where you left off. */
   recent: { id: number; name: string; updatedAt: string }[];
   /** True when the database could not be reached at all. */
@@ -43,6 +45,7 @@ const NONE: Omit<TrailSummary, 'city'> = {
   missingProfile: null,
   published: null,
   recent: [],
+  reportsThisWeek: null,
   unavailable: true,
   withWarnings: null,
 };
@@ -111,6 +114,18 @@ export async function getTrailSummary(): Promise<TrailSummary> {
       where: inCity,
     });
 
+    // Hidden reports are counted too, on purpose: this number is how an admin
+    // notices a spike worth looking at, and moderating one is not the same as
+    // it never having arrived.
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    const conditionReports = await payload.count({
+      collection: 'trail-conditions',
+      where: {
+        and: [inCity, { createdAt: { greater_than: weekAgo.toISOString() } }],
+      },
+    });
+
     return {
       city,
       drafts,
@@ -122,6 +137,7 @@ export async function getTrailSummary(): Promise<TrailSummary> {
         name: trail.displayName ?? 'Untitled',
         updatedAt: trail.updatedAt ?? '',
       })),
+      reportsThisWeek: conditionReports.totalDocs,
       unavailable: false,
       withWarnings,
     };

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -398,6 +398,94 @@ function glowId(layerId: string): string {
 function hitId(layerId: string): string {
   return `${layerId} Hit`;
 }
+function closedId(layerId: string): string {
+  return `${layerId} Closed`;
+}
+
+/**
+ * The red of a closure. One colour rather than the condition's own, because
+ * this layer means one thing — the dash is what carries it, so it still reads
+ * without relying on colour at all.
+ */
+const CLOSED_COLOR = '#dc2626';
+
+/** A filter that matches no feature, for when nothing is closed. */
+const MATCH_NOTHING: mapboxgl.FilterSpecification = [
+  'in',
+  ['to-string', ['get', 'nonexistent']],
+  ['literal', []],
+];
+
+/**
+ * Draws the closed trails as a red dashed line over their normal one.
+ *
+ * An overlay rather than a recolour so the trail keeps its rating colour — the
+ * green/blue/black scheme is what the legend and the sidebar swatches mean, and
+ * turning a trail red would leave the two disagreeing.
+ *
+ * Sits above the trail line but below its hit layer, so a closed trail is still
+ * selectable. Idempotent: safe to call on every conditions change.
+ */
+export function setClosedTrails(
+  map: mapboxgl.Map,
+  closed: MountainBikeTrail[],
+): void {
+  try {
+    for (const cfg of TRAIL_LAYERS) {
+      if (!map.getLayer(cfg.layerId)) continue;
+
+      const id = closedId(cfg.layerId);
+      const layer = map.getStyle().layers?.find((l) => l.id === cfg.layerId);
+      const source = (layer as { source?: string } | undefined)?.source;
+      if (!source) continue;
+
+      if (!map.getLayer(id)) {
+        const before = map.getLayer(hitId(cfg.layerId))
+          ? hitId(cfg.layerId)
+          : undefined;
+        map.addLayer(
+          {
+            id,
+            type: 'line',
+            source,
+            ...(cfg.sourceLayer ? { 'source-layer': cfg.sourceLayer } : {}),
+            filter: MATCH_NOTHING,
+            layout: { 'line-cap': 'butt', 'line-join': 'round' },
+            paint: {
+              'line-color': CLOSED_COLOR,
+              'line-dasharray': [1.5, 1.5],
+              'line-width': 3.5,
+            },
+          },
+          before,
+        );
+      }
+
+      map.setFilter(id, closedFilterFor(cfg, closed));
+    }
+  } catch (error) {
+    // A missing closure marker must not take the map down.
+    console.error('Failed to update closed trail layers:', error);
+  }
+}
+
+/** Matches the closed trails the way this layer identifies a trail. */
+function closedFilterFor(
+  cfg: TrailLayerConfig,
+  closed: MountainBikeTrail[],
+): mapboxgl.FilterSpecification {
+  if (closed.length === 0) {
+    return MATCH_NOTHING;
+  }
+  if (cfg.matchBy === 'osmId') {
+    const ids = closed.flatMap((trail) => trail.osmIds ?? []).map(String);
+    return ['in', ['to-string', ['get', 'OSM_ID']], ['literal', ids]];
+  }
+  // `toRawName` maps a display name back to the value in the tileset, which is
+  // what the layer's other expressions key off.
+  const names = closed.map((trail) => cfg.toRawName(trail.trailName));
+  return ['in', ['to-string', ['get', cfg.trailProp]], ['literal', names]];
+}
 
 export { TRAIL_LAYERS };
 


### PR DESCRIPTION

Stacked on #100 — base it there, not `main`, so this diff is only the conditions work.

Riders report what a trail was like, without an account, from the pane they already have open. A report is **a condition and a date**: no note, no photo, no name. The options behind the dropdown are curated in the admin like ratings and kinds, because conditions are local — "Dusty / loose" matters in Bend in August and nowhere in a Tennessee spring.

## Where it shows

- **A pill on each sidebar trail row**, so you can scan a whole complex at once.
- **The selected-trail pane** — current condition, its age, a history disclosure, and the report button.
- **The map**, for closures — see below.

Both badge surfaces hide a report older than `CONDITION_FRESH_DAYS` (14). A stale condition is worse than none: a green "Dry" pill from October is confidently wrong in March. Past the cutoff it stays in history and the pane says "last reported 3 months ago" instead.

## Closed trails are drawn on the map

A trail whose newest report is a closing condition gets a **red dashed line over** its normal one.

An overlay rather than a recolour — the green/blue/black rating colours are what the legend and the sidebar swatches mean, and turning the line red would leave the two disagreeing. The dash carries the meaning without relying on colour at all. It sits above the trail line but below the hit layer, so a closed trail is still clickable.

**Which conditions close a trail is data.** A `marksClosed` checkbox on the condition type, seeded on Closed and tickable on Snow / ice. Nothing matches on the value `'closed'`.

**A closure never expires.** Everything else fades after 14 days; a closure holds until someone reports the trail as something else — a trail doesn't reopen because nobody rode it for a fortnight. That's also why `getConditionSummary` lost its 60-day date floor: a window would have quietly reopened a trail shut last season.

## One door, and it's guarded

This is the app's first public write.

`TrailConditions`'s access rules are **admin-only on purpose** — that's what keeps Payload's own `/api/trail-conditions` shut. The write goes through `POST /api/map/conditions`, which validates and then uses the Local API. Relaxing `create` on the collection would open a second, unguarded door.

Anti-abuse is a **honeypot** (answered with a fake `200`; an error would tell the bot which field is the trap) plus a **rate limit** keyed to a salted hash of the submitter's IP — 5/hour, one per trail per 30 min. **The address itself is never stored.** No captcha, no new service, nothing a fork has to configure (ADR-0001 C3). `guard.ts` is where a captcha would go if one is ever needed.

## Closing reporting

Separately from the *condition* Closed, reporting can be switched off site-wide (Settings), per trail complex, or per trail — any one is enough — each with an optional note shown in place of the button. Most specific wins.

**Closing stops new reports and never hides old ones.** On a shut trail, what it was like when someone last rode it is the point. The server re-checks all three and answers **403**, since hiding the button is only a courtesy. These switches deliberately do **not** mark the map; muting a trail that's attracting nonsense shouldn't paint it closed for riders.

## Logging a condition from the admin

The Condition reports section on a trail takes a report inline and lists recent ones with a Hide button, so a steward posting "closed, trees down" doesn't have to leave the trail and find it again in a dropdown of several hundred. A `ui` field — no column, no migration — writing through Payload's own REST API, which the editor's session already satisfies.

## Worth a look in review

- **The elevation pane now opens for a chart *or* conditions** (`ElevationProfile.tsx`), with the chart, y-axis, stats and GPX button conditional. It used to need a chart, which would have hidden conditions on exactly the trails nobody has curated yet.
- **`Trails` gained a `beforeDelete` hook.** `trail_conditions.trail_id` is NOT NULL with an ON DELETE SET NULL FK — Payload generates that pair, and together they make Postgres *refuse* to delete a trail anyone reported on. The hook clears the reports first.
- **Three migrations**, all additive. The `marksClosed` one backfills the existing Closed row; without that, shipping it would have quietly stopped Closed meaning anything.

## Verified

`pnpm lint` clean, **547 tests pass** (47 new), `db:migrate:create` reports no schema drift.

Against a running database: honeypot writes nothing; Payload's REST endpoint 403s signed out; the 6th report in an hour and a repeat within 30 min both 429; `hidden` removes a report from badge and history; deleting a trail with reports succeeds; all three lock levels 403 with the right message and site-wide outranks a per-trail note; a 200-day-old closure still marks the trail and a newer report clears it.

**Not checked:** how the dashes look at various zooms — `[1.5, 1.5]` may need tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
